### PR TITLE
Make auto-ack streams access the message

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import cats.effect.IO
 import cats.effect.std.Random
 import scala.concurrent.duration._
 
-import de.commercetools.queue._
+import com.commercetools.queue._
 
 def publishStream(publisher: QueuePublisher[String]): Stream[IO, Nothing] =
   Stream.eval(Random.scalaUtilRandom[IO]).flatMap { random =>
@@ -41,7 +41,7 @@ def subscribeStream(subscriber: QueueSubscriber[String]): Stream[IO, Nothing] =
     // waiting max for 20 seconds
     // print every received message,
     // and ack automatically
-    .processWithAutoAck(5, 20.seconds)(IO.println(_))
+    .processWithAutoAck(5, 20.seconds)(msg => IO.println(msg.payload))
     // results are non important
     .drain
 
@@ -61,7 +61,7 @@ def program(client: QueueClient): IO[Unit] = {
 ## Working with Azure Service Bus queues
 
 ```scala
-import de.commercetools.queue.azure.servicebus._
+import com.commercetools.queue.azure.servicebus._
 import com.azure.identity.DefaultAzureCredentialBuilder
 
 val namespace = "{namespace}.servicebus.windows.net" // your namespace
@@ -74,7 +74,7 @@ ServiceBusClient(namespace, credentials).use(program(_))
 
 
 ```scala
-import de.commercetools.queue.aws.sqs._
+import com.commercetools.queue.aws.sqs._
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 

--- a/core/src/main/scala/com/commercetools/queue/Message.scala
+++ b/core/src/main/scala/com/commercetools/queue/Message.scala
@@ -1,0 +1,30 @@
+package com.commercetools.queue
+
+import java.time.Instant
+
+/**
+ * Interface to access message data received from a queue.
+ */
+trait Message[T] {
+
+  /**
+   * Unique message identifier
+   */
+  def messageId: String
+
+  /**
+   * The message payload
+   */
+  def payload: T
+
+  /**
+   * When the message was put into the queue.
+   */
+  def enqueuedAt: Instant
+
+  /**
+   * Raw message metadata (depending on the underlying queue system).
+   */
+  def metadata: Map[String, String]
+
+}

--- a/core/src/main/scala/com/commercetools/queue/MessageContext.scala
+++ b/core/src/main/scala/com/commercetools/queue/MessageContext.scala
@@ -3,34 +3,13 @@ package com.commercetools.queue
 import cats.effect.IO
 
 import java.time
-import java.time.Instant
 import scala.concurrent.duration._
 
 /**
  * Interface to interact with a message received from a queue.
  * The messages must be explicitly aknowledged after having been processed.
  */
-trait MessageContext[T] {
-
-  /**
-   * Unique message identifier
-   */
-  def messageId: String
-
-  /**
-   * The message payload
-   */
-  def payload: T
-
-  /**
-   * When the message was put into the queue.
-   */
-  def enqueuedAt: Instant
-
-  /**
-   * Raw message metadata (depending on the underlying queue system).
-   */
-  def metadata: Map[String, String]
+trait MessageContext[T] extends Message[T] {
 
   /**
    * Acknowledges the message. It will be removed from the queue, so that

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ import cats.effect.IO
 import cats.effect.std.Random
 import scala.concurrent.duration._
 
-import de.commercetools.queue._
+import com.commercetools.queue._
 
 def publishStream(publisher: QueuePublisher[String]): Stream[IO, Nothing] =
   Stream.eval(Random.scalaUtilRandom[IO]).flatMap { random =>
@@ -41,7 +41,7 @@ def subscribeStream(subscriber: QueueSubscriber[String]): Stream[IO, Nothing] =
     // waiting max for 20 seconds
     // print every received message,
     // and ack automatically
-    .processWithAutoAck(5, 20.seconds)(IO.println(_))
+    .processWithAutoAck(5, 20.seconds)(msg => IO.println(msg.payload))
     // results are non important
     .drain
 
@@ -61,7 +61,7 @@ def program(client: QueueClient): IO[Unit] = {
 ## Working with Azure Service Bus queues
 
 ```scala mdoc:compile-only
-import de.commercetools.queue.azure.servicebus._
+import com.commercetools.queue.azure.servicebus._
 import com.azure.identity.DefaultAzureCredentialBuilder
 
 val namespace = "{namespace}.servicebus.windows.net" // your namespace
@@ -74,7 +74,7 @@ ServiceBusClient(namespace, credentials).use(program(_))
 
 
 ```scala mdoc:compile-only
-import de.commercetools.queue.aws.sqs._
+import com.commercetools.queue.aws.sqs._
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 


### PR DESCRIPTION
This allows for these variant to use the metadata, without having control over the lifecycle of the message, which is managed by the stream itself.