### PR TITLE
Publish messages with metadata

### DIFF
--- a/azure/service-bus/src/main/scala/com/commercetools/queue/azure/servicebus/ServiceBusMessageContext.scala
+++ b/azure/service-bus/src/main/scala/com/commercetools/queue/azure/servicebus/ServiceBusMessageContext.scala
@@ -37,7 +37,7 @@ class ServiceBusMessageContext[F[_], T](
 
   override def metadata: Map[String, String] =
     underlying.getRawAmqpMessage.getApplicationProperties.asScala.view.collect {
-      case (k, v) if v.isInstanceOf[String] => (k, v.asInstanceOf[String])
+      case (k, v: String) => (k, v)
     }.toMap
 
   override def ack(): F[Unit] =

--- a/azure/service-bus/src/main/scala/com/commercetools/queue/azure/servicebus/ServiceBusMessageContext.scala
+++ b/azure/service-bus/src/main/scala/com/commercetools/queue/azure/servicebus/ServiceBusMessageContext.scala
@@ -35,9 +35,9 @@ class ServiceBusMessageContext[F[_], T](
 
   override def enqueuedAt: Instant = underlying.getEnqueuedTime().toInstant()
 
-  override def metadata: Map[String, String] =
-    underlying.getRawAmqpMessage.getApplicationProperties.asScala.view.collect {
-      case (k, v: String) => (k, v)
+  override lazy val metadata: Map[String, String] =
+    underlying.getRawAmqpMessage.getApplicationProperties.asScala.view.collect { case (k, v: String) =>
+      (k, v)
     }.toMap
 
   override def ack(): F[Unit] =

--- a/build.sbt
+++ b/build.sbt
@@ -93,6 +93,7 @@ lazy val otel4s = crossProject(JVMPlatform)
     libraryDependencies ++= List(
       "org.typelevel" %%% "otel4s-core" % "0.7.0"
     ),
+    // TODO: Remove once 0.2 is published
     mimaBinaryIssueFilters ++= List(
       ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.otel4s.MeasuringQueuePusher.push")
     )
@@ -120,6 +121,7 @@ lazy val azureServiceBus = crossProject(JVMPlatform)
     libraryDependencies ++= List(
       "com.azure" % "azure-messaging-servicebus" % "7.17.0"
     ),
+    // TODO: Remove once 0.2 is published
     mimaBinaryIssueFilters ++= List(
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "com.commercetools.queue.azure.servicebus.ServiceBusPusher.push")

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,9 @@ lazy val core = crossProject(JVMPlatform)
     // TODO: Remove once 0.2 is published
     mimaBinaryIssueFilters ++= List(
       ProblemFilters.exclude[ReversedMissingMethodProblem]("com.commercetools.queue.Message.rawPayload"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.commercetools.queue.QueueAdministration.configuration")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.commercetools.queue.QueueAdministration.configuration"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.QueuePusher.push"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.commercetools.queue.QueuePusher.push")
     )
   )
 
@@ -90,6 +92,9 @@ lazy val otel4s = crossProject(JVMPlatform)
     description := "Support for metrics and tracing using otel4s",
     libraryDependencies ++= List(
       "org.typelevel" %%% "otel4s-core" % "0.7.0"
+    ),
+    mimaBinaryIssueFilters ++= List(
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.otel4s.MeasuringQueuePusher.push")
     )
   )
   .dependsOn(core % "compile->compile;test->test")
@@ -114,6 +119,10 @@ lazy val azureServiceBus = crossProject(JVMPlatform)
     name := "fs2-queues-azure-service-bus",
     libraryDependencies ++= List(
       "com.azure" % "azure-messaging-servicebus" % "7.17.0"
+    ),
+    mimaBinaryIssueFilters ++= List(
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "com.commercetools.queue.azure.servicebus.ServiceBusPusher.push")
     )
   )
   .dependsOn(core, testkit % Test)
@@ -129,7 +138,8 @@ lazy val awsSQS = crossProject(JVMPlatform)
     ),
     // TODO: Remove once 0.2 is published
     mimaBinaryIssueFilters ++= List(
-      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.aws.sqs.SQSMessageContext.this")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.aws.sqs.SQSMessageContext.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.aws.sqs.SQSPusher.push")
     )
   )
   .dependsOn(core)

--- a/core/src/main/scala/com/commercetools/queue/QueuePublisher.scala
+++ b/core/src/main/scala/com/commercetools/queue/QueuePublisher.scala
@@ -41,7 +41,7 @@ abstract class QueuePublisher[F[_], T](implicit F: MonadCancel[F, Throwable]) {
    * produced data to the queue. The messages are published in batches, according
    * to the `batchSize` parameter.
    */
-  def sink(batchSize: Int = 10)(upstream: Stream[F, T]): Stream[F, Nothing] =
+  def sink(batchSize: Int = 10)(upstream: Stream[F, (T, Map[String, String])]): Stream[F, Nothing] =
     Stream.resource(pusher).flatMap { pusher =>
       upstream.chunkN(batchSize).foreach { chunk =>
         pusher.push(chunk.toList, None)

--- a/core/src/main/scala/com/commercetools/queue/QueuePusher.scala
+++ b/core/src/main/scala/com/commercetools/queue/QueuePusher.scala
@@ -35,6 +35,6 @@ trait QueuePusher[F[_], T] {
   /**
    * Publishes a bunch of messages to the queue, with an optional delay.
    */
-  def push(messages: (List[(T, Map[String, String])]), delay: Option[FiniteDuration]): F[Unit]
+  def push(messages: List[(T, Map[String, String])], delay: Option[FiniteDuration]): F[Unit]
 
 }

--- a/core/src/main/scala/com/commercetools/queue/QueuePusher.scala
+++ b/core/src/main/scala/com/commercetools/queue/QueuePusher.scala
@@ -30,11 +30,11 @@ trait QueuePusher[F[_], T] {
   /**
    * Publishes a single message to the queue, with an optional delay.
    */
-  def push(message: T, delay: Option[FiniteDuration]): F[Unit]
+  def push(message: T, metadata: Map[String, String], delay: Option[FiniteDuration]): F[Unit]
 
   /**
    * Publishes a bunch of messages to the queue, with an optional delay.
    */
-  def push(messages: List[T], delay: Option[FiniteDuration]): F[Unit]
+  def push(messages: (List[(T, Map[String, String])]), delay: Option[FiniteDuration]): F[Unit]
 
 }

--- a/core/src/test/scala/com/commercetools/queue/testing/TestQueue.scala
+++ b/core/src/test/scala/com/commercetools/queue/testing/TestQueue.scala
@@ -119,17 +119,17 @@ class TestQueue[T](
         Chunk.chain(newlyLocked.map(_._2)))
     }
 
-  def enqeueMessages(messages: List[T], delay: Option[FiniteDuration]) =
+  def enqeueMessages(messages: List[(T, Map[String, String])], delay: Option[FiniteDuration]) =
     state.evalUpdate { state =>
       for {
         now <- IO.realTimeInstant
         state <- update(state)
       } yield delay match {
         case None =>
-          state.copy(available = state.available.addAll(messages.map(TestMessage(_, now))))
+          state.copy(available = state.available.addAll(messages.map(x => TestMessage(x._1, now))))
         case Some(delay) =>
           val delayed = now.plusMillis(delay.toMillis)
-          state.copy(delayed = messages.map(TestMessage(_, delayed)) reverse_::: state.delayed)
+          state.copy(delayed = messages.map(x => TestMessage(x._1, delayed)) reverse_::: state.delayed)
       }
     }
 

--- a/core/src/test/scala/com/commercetools/queue/testing/TestQueuePusher.scala
+++ b/core/src/test/scala/com/commercetools/queue/testing/TestQueuePusher.scala
@@ -25,10 +25,10 @@ class TestQueuePusher[T](queue: TestQueue[T]) extends QueuePusher[IO, T] {
 
   override val queueName: String = queue.name
 
-  override def push(message: T, delay: Option[FiniteDuration]): IO[Unit] =
-    queue.enqeueMessages(message :: Nil, delay)
+  override def push(message: T, metadata: Map[String, String], delay: Option[FiniteDuration]): IO[Unit] =
+    queue.enqeueMessages((message, metadata) :: Nil, delay)
 
-  override def push(messages: List[T], delay: Option[FiniteDuration]): IO[Unit] =
+  override def push(messages: List[(T, Map[String, String])], delay: Option[FiniteDuration]): IO[Unit] =
     queue.enqeueMessages(messages, delay)
 
 }

--- a/docs/getting-started/publishing.md
+++ b/docs/getting-started/publishing.md
@@ -26,10 +26,10 @@ The pipe takes a parameter allowing for batching publications.
 ```scala mdoc:compile-only
 import fs2.{Pipe, Stream}
 
-val input: Stream[IO, String] = ???
+val input: Stream[IO, (String, Map[String, String])] = ???
 
 // messages are published in batch of 10
-val publicationSink: Pipe[IO, String, Nothing] = publisher.sink(batchSize = 10)
+val publicationSink: Pipe[IO, (String, Map[String, String]), Nothing] = publisher.sink(batchSize = 10)
 
 // pipe the message producing stream through the publication sink
 input.through(publicationSink)
@@ -48,7 +48,7 @@ A `QueuePusher` is accessed as a [`Resource`][cats-effect-resource] as it usuall
 
 ```scala mdoc:compile-only
 publisher.pusher.use { queuePusher =>
-  val produceMessages: IO[List[String]] = ???
+  val produceMessages: IO[List[(String, Map[String, String])]] = ???
 
   // produce a batch
   produceMessages
@@ -69,7 +69,7 @@ If you need to spawn background fibers using the `queuePusher`, you can for inst
 import cats.effect.std.Supervisor
 
 publisher.pusher.use { queuePusher =>
-  val produceMessages: IO[List[String]] = ???
+  val produceMessages: IO[List[(String, Map[String, String])]] = ???
 
   // create a supervisor that waits for supervised spawn fibers
   // to finish before being released

--- a/otel4s/src/main/scala/com/commercetools/queue/otel4s/MeasuringQueuePusher.scala
+++ b/otel4s/src/main/scala/com/commercetools/queue/otel4s/MeasuringQueuePusher.scala
@@ -32,16 +32,16 @@ class MeasuringQueuePusher[F[_], T](
 
   override def queueName: String = underlying.queueName
 
-  override def push(message: T, delay: Option[FiniteDuration]): F[Unit] =
+  override def push(message: T, metadata: Map[String, String], delay: Option[FiniteDuration]): F[Unit] =
     tracer
       .span("queue.pushMessage")
       .surround {
         underlying
-          .push(message, delay)
+          .push(message, metadata, delay)
       }
       .guaranteeCase(metrics.send)
 
-  override def push(messages: List[T], delay: Option[FiniteDuration]): F[Unit] =
+  override def push(messages: List[(T, Map[String, String])], delay: Option[FiniteDuration]): F[Unit] =
     tracer
       .span("queue.pushMessages")
       .surround {

--- a/otel4s/src/test/scala/com/commercetools/queue/otel4s/MeasuringPusherSuite.scala
+++ b/otel4s/src/test/scala/com/commercetools/queue/otel4s/MeasuringPusherSuite.scala
@@ -36,9 +36,11 @@ class MeasuringPusherSuite extends CatsEffectSuite {
 
     override def queueName: String = self.queueName
 
-    override def push(message: String, delay: Option[FiniteDuration]): IO[Unit] = result
+    override def push(message: String, metadata: Map[String, String], delay: Option[FiniteDuration]): IO[Unit] =
+      result
 
-    override def push(messages: List[String], delay: Option[FiniteDuration]): IO[Unit] = result
+    override def push(messages: List[(String, Map[String, String])], delay: Option[FiniteDuration]): IO[Unit] =
+      result
 
   }
 
@@ -47,7 +49,7 @@ class MeasuringPusherSuite extends CatsEffectSuite {
       val measuringPusher =
         new MeasuringQueuePusher[IO, String](pusher(IO.unit), new QueueMetrics(queueName, counter), Tracer.noop)
       for {
-        fiber <- measuringPusher.push("msg", None).start
+        fiber <- measuringPusher.push("msg", Map.empty, None).start
         _ <- assertIO(fiber.join.map(_.isSuccess), true)
         _ <- assertIO(
           counter.records.get,
@@ -61,7 +63,7 @@ class MeasuringPusherSuite extends CatsEffectSuite {
       val measuringPusher =
         new MeasuringQueuePusher[IO, String](pusher(IO.unit), new QueueMetrics(queueName, counter), Tracer.noop)
       for {
-        fiber <- measuringPusher.push(List("msg1", "msg2", "msg3"), None).start
+        fiber <- measuringPusher.push(List("msg1", "msg2", "msg3").map(x => (x, Map.empty)), None).start
         _ <- assertIO(fiber.join.map(_.isSuccess), true)
         _ <- assertIO(
           counter.records.get,
@@ -78,7 +80,7 @@ class MeasuringPusherSuite extends CatsEffectSuite {
           new QueueMetrics(queueName, counter),
           Tracer.noop)
       for {
-        fiber <- measuringPusher.push("msg", None).start
+        fiber <- measuringPusher.push("msg", Map.empty, None).start
         _ <- assertIO(fiber.join.map(_.isError), true)
         _ <- assertIO(
           counter.records.get,
@@ -95,7 +97,7 @@ class MeasuringPusherSuite extends CatsEffectSuite {
           new QueueMetrics(queueName, counter),
           Tracer.noop)
       for {
-        fiber <- measuringPusher.push(List("msg1", "msg2", "msg3"), None).start
+        fiber <- measuringPusher.push(List("msg1", "msg2", "msg3").map(x => (x, Map.empty)), None).start
         _ <- assertIO(fiber.join.map(_.isError), true)
         _ <- assertIO(
           counter.records.get,
@@ -109,7 +111,7 @@ class MeasuringPusherSuite extends CatsEffectSuite {
       val measuringPusher =
         new MeasuringQueuePusher[IO, String](pusher(IO.canceled), new QueueMetrics(queueName, counter), Tracer.noop)
       for {
-        fiber <- measuringPusher.push("msg", None).start
+        fiber <- measuringPusher.push("msg", Map.empty, None).start
         _ <- assertIO(fiber.join.map(_.isCanceled), true)
         _ <- assertIO(
           counter.records.get,
@@ -123,7 +125,7 @@ class MeasuringPusherSuite extends CatsEffectSuite {
       val measuringPusher =
         new MeasuringQueuePusher[IO, String](pusher(IO.canceled), new QueueMetrics(queueName, counter), Tracer.noop)
       for {
-        fiber <- measuringPusher.push(List("msg1", "msg2", "msg3"), None).start
+        fiber <- measuringPusher.push(List("msg1", "msg2", "msg3").map(x => (x, Map.empty)), None).start
         _ <- assertIO(fiber.join.map(_.isCanceled), true)
         _ <- assertIO(
           counter.records.get,

--- a/testkit/src/main/scala/com/commercetools/queue/testkit/QueueClientSuite.scala
+++ b/testkit/src/main/scala/com/commercetools/queue/testkit/QueueClientSuite.scala
@@ -53,7 +53,7 @@ abstract class QueueClientSuite extends CatsEffectSuite {
           client
             .subscribe(queueName)
             .processWithAutoAck(batchSize = 10, waitingTime = 20.seconds)(msg =>
-              received.update((msg.rawPayload, msg.metadata) :: _))
+              received.update(_ :+ (msg.rawPayload, msg.metadata)))
             .take(size)
         )
         .compile
@@ -62,7 +62,7 @@ abstract class QueueClientSuite extends CatsEffectSuite {
         if (receivedMessages.size != messages.size)
           fail(s"expected to receive ${messages.size} messages, got ${receivedMessages.size}")
 
-        messages.sortBy(_._1).toSet.zip(receivedMessages.sortBy(_._1).toSet).forall {
+        messages.zip(receivedMessages).forall {
           case ((expectedPayload, expectedMetadata), (actualPayload, actualMetadata)) =>
             if (expectedPayload != actualPayload)
               fail(s"expected payload '$expectedPayload', got '$actualPayload'")


### PR DESCRIPTION
This PR is adding support to publish metadata (aka message properties, headers, etc..).

All the 3 providers we're currently supporting support some kind of application metadata ([sqs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_MessageAttributeValue.html#API_MessageAttributeValue_Contents), [pubsub](https://cloud.google.com/pubsub/docs/samples/pubsub-publish-custom-attributes#pubsub_publish_custom_attributes-java), [servicebus](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusmessage.applicationproperties?view=azure-dotnet#remarks)), and an encoding that basically can cover all of them is having them as a `Map[String, String]`. That's not the most typed definition ever, but it gets the job done.