### PR TITLE
Add support for dead letter queues

### DIFF
--- a/aws/sqs/src/main/scala/com/commercetools/queue/aws/sqs/SQSClient.scala
+++ b/aws/sqs/src/main/scala/com/commercetools/queue/aws/sqs/SQSClient.scala
@@ -28,7 +28,8 @@ import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest
 
 import java.net.URI
 
-class SQSClient[F[_]] private (client: SqsAsyncClient)(implicit F: Async[F]) extends QueueClient[F] {
+class SQSClient[F[_]] private (client: SqsAsyncClient, makeDLQName: String => String)(implicit F: Async[F])
+  extends QueueClient[F] {
 
   private def getQueueUrl(name: String): F[String] =
     F.fromCompletableFuture {
@@ -39,7 +40,7 @@ class SQSClient[F[_]] private (client: SqsAsyncClient)(implicit F: Async[F]) ext
       .adaptError(makeQueueException(_, name))
 
   override def administration: QueueAdministration[F] =
-    new SQSAdministration(client, getQueueUrl(_))
+    new SQSAdministration(client, getQueueUrl(_), makeDLQName)
 
   override def publish[T: Serializer](name: String): QueuePublisher[F, T] =
     new SQSPublisher(name, client, getQueueUrl(name))
@@ -51,9 +52,26 @@ class SQSClient[F[_]] private (client: SqsAsyncClient)(implicit F: Async[F]) ext
 
 object SQSClient {
 
+  private def defaultMakeDLQName(name: String): String =
+    s"$name-dlq"
+
+  /**
+   * Creates a new [[SQSClient]].
+   *
+   * @param region the region to use
+   * @param credentials the credentials to use
+   * @param makeDLQName how the dead letter queue name is derived from the queue name
+   *                    by default it suffixes the queue name with `-dlq`
+   * @param httpClient the existing HTTP client to use.
+   *                   '''Note:''' if provided, it is not closed when resource is released,
+   *                   otherwise the client manages its own client and will close it when
+   *                   released
+   * @param endpoint the service endpoint to use.
+   */
   def apply[F[_]](
     region: Region,
     credentials: AwsCredentialsProvider,
+    makeDLQName: String => String = defaultMakeDLQName,
     endpoint: Option[URI] = None,
     httpClient: Option[SdkAsyncHttpClient] = None
   )(implicit F: Async[F]
@@ -71,6 +89,6 @@ object SQSClient {
           builder.build()
         }
       }
-      .map(new SQSClient(_))
+      .map(new SQSClient(_, makeDLQName))
 
 }

--- a/azure/service-bus/src/main/scala/com/commercetools/queue/azure/servicebus/ServiceBusAdministration.scala
+++ b/azure/service-bus/src/main/scala/com/commercetools/queue/azure/servicebus/ServiceBusAdministration.scala
@@ -21,7 +21,7 @@ import cats.syntax.functor._
 import cats.syntax.monadError._
 import com.azure.messaging.servicebus.administration.ServiceBusAdministrationClient
 import com.azure.messaging.servicebus.administration.models.CreateQueueOptions
-import com.commercetools.queue.{QueueAdministration, QueueConfiguration}
+import com.commercetools.queue.{DeadletterQueueConfiguration, QueueAdministration, QueueConfiguration, QueueCreationConfiguration}
 
 import java.time.Duration
 import scala.concurrent.duration._
@@ -29,14 +29,26 @@ import scala.concurrent.duration._
 class ServiceBusAdministration[F[_]](client: ServiceBusAdministrationClient)(implicit F: Async[F])
   extends QueueAdministration[F] {
 
-  override def create(name: String, messageTTL: FiniteDuration, lockTTL: FiniteDuration): F[Unit] =
-    F.blocking(
+  override def create(name: String, configuration: QueueCreationConfiguration): F[Unit] =
+    F.blocking {
+      val options = new CreateQueueOptions()
+        .setDefaultMessageTimeToLive(Duration.ofMillis(configuration.messageTTL.toMillis))
+        .setLockDuration(Duration.ofMillis(configuration.lockTTL.toMillis))
+      configuration.deadletter match {
+        case Some(configuration) =>
+          options
+            .setMaxDeliveryCount(configuration.maxAttempts)
+            .setDeadLetteringOnMessageExpiration(true)
+        case None =>
+          options
+            .setMaxDeliveryCount(Int.MaxValue)
+            .setDeadLetteringOnMessageExpiration(false)
+      }
       client.createQueue(
         name,
-        new CreateQueueOptions()
-          .setDefaultMessageTimeToLive(Duration.ofMillis(messageTTL.toMillis))
-          .setLockDuration(Duration.ofMillis(lockTTL.toMillis))))
-      .void
+        options
+      )
+    }.void
       .adaptError(makeQueueException(_, name))
 
   override def update(name: String, messageTTL: Option[FiniteDuration], lockTTL: Option[FiniteDuration]): F[Unit] =
@@ -45,15 +57,19 @@ class ServiceBusAdministration[F[_]](client: ServiceBusAdministrationClient)(imp
       messageTTL.foreach(ttl => properties.setDefaultMessageTimeToLive(Duration.ofMillis(ttl.toMillis)))
       lockTTL.foreach(ttl => properties.setLockDuration(Duration.ofMillis(ttl.toMillis)))
       val _ = client.updateQueue(properties)
-    }
+    }.adaptError(makeQueueException(_, name))
 
   override def configuration(name: String): F[QueueConfiguration] =
     F.blocking {
       val properties = client.getQueue(name)
       val messageTTL = properties.getDefaultMessageTimeToLive().toMillis.millis
       val lockTTL = properties.getLockDuration().toMillis.millis
-      QueueConfiguration(messageTTL = messageTTL, lockTTL = lockTTL)
-    }
+      val deadletter =
+        Option.when(properties.isDeadLetteringOnMessageExpiration())(
+          DeadletterQueueConfiguration(properties.getForwardDeadLetteredMessagesTo(), properties.getMaxDeliveryCount()))
+
+      QueueConfiguration(messageTTL = messageTTL, lockTTL = lockTTL, deadletter = deadletter)
+    }.adaptError(makeQueueException(_, name))
 
   override def delete(name: String): F[Unit] =
     F.blocking(client.deleteQueue(name))

--- a/core/src/main/scala/com/commercetools/queue/DeadletterQueueConfiguration.scala
+++ b/core/src/main/scala/com/commercetools/queue/DeadletterQueueConfiguration.scala
@@ -1,0 +1,7 @@
+package com.commercetools.queue
+
+/**
+ * @param name the name of the deadletter queue
+ * @param maxAttempts the maximum number of delivery attempts made before forwarding a message to the dead letter queue
+ */
+final case class DeadletterQueueConfiguration(name: String, maxAttempts: Int)

--- a/core/src/main/scala/com/commercetools/queue/DeadletterQueueCreationConfiguration.scala
+++ b/core/src/main/scala/com/commercetools/queue/DeadletterQueueCreationConfiguration.scala
@@ -1,0 +1,3 @@
+package com.commercetools.queue
+
+final case class DeadletterQueueCreationConfiguration(maxAttempts: Int)

--- a/core/src/main/scala/com/commercetools/queue/QueueAdministration.scala
+++ b/core/src/main/scala/com/commercetools/queue/QueueAdministration.scala
@@ -23,8 +23,13 @@ import scala.concurrent.duration.FiniteDuration
  */
 trait QueueAdministration[F[_]] {
 
-  /** Creates a queue with the given name, message TTL and lock TTL. */
-  def create(name: String, messageTTL: FiniteDuration, lockTTL: FiniteDuration): F[Unit]
+  /**
+   * Creates a queue with the given name and configuration.
+   * If the configuration contains a `deadletter` element, a dead letter
+   * queue is created and associated to the main queue with the configured
+   * maximum delivery attempt.
+   */
+  def create(name: String, configuration: QueueCreationConfiguration): F[Unit]
 
   /**
    * Updates the queue with the given name, with provided message TTL and/or lock TTL.

--- a/core/src/main/scala/com/commercetools/queue/QueueConfiguration.scala
+++ b/core/src/main/scala/com/commercetools/queue/QueueConfiguration.scala
@@ -18,4 +18,12 @@ package com.commercetools.queue
 
 import scala.concurrent.duration.FiniteDuration
 
-final case class QueueConfiguration(messageTTL: FiniteDuration, lockTTL: FiniteDuration)
+/**
+ * @param messageTTL the time a message is guaranteed to stay in the queue before being discarded by the underlying system
+ * @param lockTTL the time a message is locked (or leased) upon reception by a subscriber before being eligible to redelivery
+ * @param deadletter the dead-letter queue configuration if any
+ */
+final case class QueueConfiguration(
+  messageTTL: FiniteDuration,
+  lockTTL: FiniteDuration,
+  deadletter: Option[DeadletterQueueConfiguration])

--- a/core/src/main/scala/com/commercetools/queue/QueueCreationConfiguration.scala
+++ b/core/src/main/scala/com/commercetools/queue/QueueCreationConfiguration.scala
@@ -1,0 +1,18 @@
+package com.commercetools.queue
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * Configuration provided upon queue creation.
+ *
+ * @param messageTTL the time a message is kept in the queue before being discarded
+ * @param lockTTL the time a message is locked (or leased) after having been delivered
+ *                to a consumer and before being made available to other again
+ * @param deadletter whether to create a dead letter queue associated to this queue
+ *                   with the configured amount of delivery tries before moving a message
+ *                   to the dead letter queue
+ */
+final case class QueueCreationConfiguration(
+  messageTTL: FiniteDuration,
+  lockTTL: FiniteDuration,
+  deadletter: Option[DeadletterQueueCreationConfiguration])

--- a/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubAdministration.scala
+++ b/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubAdministration.scala
@@ -18,7 +18,7 @@ package com.commercetools.queue.gcp.pubsub
 
 import cats.effect.{Async, Resource}
 import cats.syntax.all._
-import com.commercetools.queue.{QueueAdministration, QueueConfiguration}
+import com.commercetools.queue.{DeadletterQueueConfiguration, QueueAdministration, QueueConfiguration, QueueCreationConfiguration}
 import com.google.api.gax.core.CredentialsProvider
 import com.google.api.gax.rpc.{NotFoundException, TransportChannelProvider}
 import com.google.cloud.pubsub.v1.{SubscriptionAdminClient, SubscriptionAdminSettings, TopicAdminClient, TopicAdminSettings}
@@ -31,7 +31,8 @@ class PubSubAdministration[F[_]](
   project: String,
   channelProvider: TransportChannelProvider,
   credentials: CredentialsProvider,
-  endpoint: Option[String]
+  endpoint: Option[String],
+  makeDLQName: String => String
 )(implicit F: Async[F])
   extends QueueAdministration[F] {
 
@@ -53,9 +54,9 @@ class PubSubAdministration[F[_]](
     SubscriptionAdminClient.create(builder.build())
   })
 
-  override def create(name: String, messageTTL: FiniteDuration, lockTTL: FiniteDuration): F[Unit] = {
+  override def create(name: String, configuration: QueueCreationConfiguration): F[Unit] = {
     val topicName = TopicName.of(project, name)
-    val ttl = Duration.newBuilder().setSeconds(messageTTL.toSeconds).build()
+    val ttl = Duration.newBuilder().setSeconds(configuration.messageTTL.toSeconds).build()
     adminClient.use { client =>
       wrapFuture(F.delay {
         client
@@ -71,7 +72,7 @@ class PubSubAdministration[F[_]](
               .newBuilder()
               .setTopic(topicName.toString())
               .setName(SubscriptionName.of(project, s"fs2-queue-$name").toString())
-              .setAckDeadlineSeconds(lockTTL.toSeconds.toInt)
+              .setAckDeadlineSeconds(configuration.lockTTL.toSeconds.toInt)
               .setMessageRetentionDuration(ttl)
               // An empty expiration policy (no TTL set) ensures the subscription is never deleted
               .setExpirationPolicy(ExpirationPolicy.newBuilder().build())
@@ -146,21 +147,28 @@ class PubSubAdministration[F[_]](
   }
 
   override def configuration(name: String): F[QueueConfiguration] =
-    subscriptionClient.use { client =>
-      wrapFuture[F, Subscription](F.delay {
-        val subscriptionName = SubscriptionName.of(project, s"fs2-queue-$name")
-        client
-          .getSubscriptionCallable()
-          .futureCall(GetSubscriptionRequest.newBuilder().setSubscription(subscriptionName.toString()).build())
-      }).map { (sub: Subscription) =>
-        val messageTTL =
-          sub.getMessageRetentionDuration().getSeconds.seconds +
-            sub.getMessageRetentionDuration().getNanos().nanos
-        val lockTTL =
-          sub.getAckDeadlineSeconds().seconds
-        QueueConfiguration(messageTTL = messageTTL, lockTTL = lockTTL)
+    subscriptionClient
+      .use { client =>
+        wrapFuture(F.delay {
+          val subscriptionName = SubscriptionName.of(project, s"fs2-queue-$name")
+          client
+            .getSubscriptionCallable()
+            .futureCall(GetSubscriptionRequest.newBuilder().setSubscription(subscriptionName.toString()).build())
+        }).map { (sub: Subscription) =>
+          val messageTTL =
+            sub.getMessageRetentionDuration().getSeconds.seconds +
+              sub.getMessageRetentionDuration().getNanos().nanos
+          val lockTTL =
+            sub.getAckDeadlineSeconds().seconds
+          val policy = sub.getDeadLetterPolicy()
+          val deadletter =
+            Option(TopicName.parse(policy.getDeadLetterTopic())).map { topicName =>
+              DeadletterQueueConfiguration(topicName.toString(), policy.getMaxDeliveryAttempts())
+            }
+          QueueConfiguration(messageTTL = messageTTL, lockTTL = lockTTL, deadletter = deadletter)
+        }
       }
-    }
+      .adaptError(makeQueueException(_, name))
 
   override def delete(name: String): F[Unit] = {
     adminClient.use { client =>

--- a/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubClient.scala
+++ b/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubClient.scala
@@ -28,11 +28,12 @@ class PubSubClient[F[_]: Async] private (
   channelProvider: TransportChannelProvider,
   useGrpc: Boolean,
   credentials: CredentialsProvider,
-  endpoint: Option[String])
+  endpoint: Option[String],
+  makeDLQName: String => String)
   extends QueueClient[F] {
 
   override def administration: QueueAdministration[F] =
-    new PubSubAdministration[F](project, channelProvider, credentials, endpoint)
+    new PubSubAdministration[F](project, channelProvider, credentials, endpoint, makeDLQName)
 
   override def publish[T: Serializer](name: String): QueuePublisher[F, T] =
     new PubSubPublisher[F, T](name, TopicName.of(project, name), channelProvider, credentials, endpoint)
@@ -54,27 +55,60 @@ object PubSubClient {
     HttpJsonTransportChannel.create(
       ManagedHttpJsonChannel.newBuilder().setEndpoint(endpoint.getOrElse("https://pubsub.googleapis.com")).build())
 
+  private def makeDefaultDLQName(name: String): String =
+    s"$name-dlq"
+
+  /**
+   * Creates a [[PubSubClient]].
+   *
+   * @param project the project to use
+   * @param credentials the credentials to use
+   * @param makeDLQName how the dead letter queue name is derived from the queue name
+   *                    by default it suffixes the queue name with `-dlq`
+   * @param endpoint the service endpoint to use
+   * @param mkTransportChannel how the HTTP transport channel is created
+   *                           by default it uses the `NetHttpTransport` client
+   */
   def apply[F[_]](
     project: String,
     credentials: CredentialsProvider,
+    makeDLQName: String => String = makeDefaultDLQName,
     endpoint: Option[String] = None,
-    mkTransportChannel: Option[String] => HttpJsonTransportChannel = makeDefaultTransportChannel _
+    mkTransportChannel: Option[String] => HttpJsonTransportChannel = makeDefaultTransportChannel
   )(implicit F: Async[F]
   ): Resource[F, PubSubClient[F]] =
     Resource
       .fromAutoCloseable(F.blocking(mkTransportChannel(endpoint)))
       .map { channel =>
-        new PubSubClient[F](project, FixedTransportChannelProvider.create(channel), false, credentials, endpoint)
+        new PubSubClient[F](
+          project,
+          FixedTransportChannelProvider.create(channel),
+          false,
+          credentials,
+          endpoint,
+          makeDLQName)
       }
 
+  /**
+   * Creates an unmanaged [[PubSubClient]].
+   *
+   * @param project the project to use
+   * @param credentials the credentials to use
+   * @param makeDLQName how the dead letter queue name is derived from the queue name
+   *                    by default it suffixes the queue name with `-dlq`
+   * @param channelProvider the channel provider to use, needs to be managed by caller
+   * @param useGrpc whether the channel provider uses gRPC
+   * @param endpoint the service endpoint to use
+   */
   def unmanaged[F[_]](
     project: String,
     credentials: CredentialsProvider,
     channelProvider: TransportChannelProvider,
     useGrpc: Boolean,
+    makeDLQName: String => String = makeDefaultDLQName,
     endpoint: Option[String] = None
   )(implicit F: Async[F]
   ): PubSubClient[F] =
-    new PubSubClient[F](project, channelProvider, useGrpc, credentials, endpoint)
+    new PubSubClient[F](project, channelProvider, useGrpc, credentials, endpoint, makeDLQName)
 
 }

--- a/otel4s/src/main/scala/com/commercetools/queue/otel4s/MeasuringQueueAdministration.scala
+++ b/otel4s/src/main/scala/com/commercetools/queue/otel4s/MeasuringQueueAdministration.scala
@@ -18,7 +18,7 @@ package com.commercetools.queue.otel4s
 
 import cats.effect.MonadCancel
 import cats.effect.syntax.monadCancel._
-import com.commercetools.queue.{QueueAdministration, QueueConfiguration}
+import com.commercetools.queue.{QueueAdministration, QueueConfiguration, QueueCreationConfiguration}
 import org.typelevel.otel4s.Attribute
 import org.typelevel.otel4s.metrics.Counter
 import org.typelevel.otel4s.trace.Tracer
@@ -32,11 +32,11 @@ class MeasuringQueueAdministration[F[_]](
 )(implicit F: MonadCancel[F, Throwable])
   extends QueueAdministration[F] {
 
-  override def create(name: String, messageTTL: FiniteDuration, lockTTL: FiniteDuration): F[Unit] =
+  override def create(name: String, configuration: QueueCreationConfiguration): F[Unit] =
     tracer
       .span("queue.create")
       .surround {
-        underlying.create(name, messageTTL, lockTTL)
+        underlying.create(name, configuration)
       }
       .guaranteeCase(QueueMetrics.increment(Attribute("queue", name), QueueMetrics.create, requestCounter))
 

--- a/testkit/src/main/scala/com/commercetools/queue/testkit/QueueClientSuite.scala
+++ b/testkit/src/main/scala/com/commercetools/queue/testkit/QueueClientSuite.scala
@@ -2,7 +2,7 @@ package com.commercetools.queue.testkit
 
 import cats.effect.std.Random
 import cats.effect.{IO, Ref, Resource}
-import com.commercetools.queue.{QueueClient, QueueConfiguration}
+import com.commercetools.queue.{QueueClient, QueueConfiguration, QueueCreationConfiguration}
 import fs2.{Chunk, Stream}
 import munit.CatsEffectSuite
 
@@ -34,7 +34,7 @@ abstract class QueueClientSuite extends CatsEffectSuite {
           .map(uuid => s"queue-$uuid")
           .flatTap { queueName =>
             clientFixture().administration
-              .create(queueName, originalMessageTTL, originalLockTTL)
+              .create(queueName, QueueCreationConfiguration(originalMessageTTL, originalLockTTL, None))
           })(queueName => clientFixture().administration.delete(queueName)))
 
   withQueue.test("published messages are received by a processor") { queueName =>
@@ -91,15 +91,15 @@ abstract class QueueClientSuite extends CatsEffectSuite {
   }
 
   withQueue.test("configuration can be updated") { queueName =>
-    assume(queueUpdateSupported, "The test environment does not support queue update")
     val client = clientFixture()
     val admin = client.administration
     for {
-      _ <- assertIO(admin.configuration(queueName), QueueConfiguration(originalMessageTTL, originalLockTTL))
+      _ <- assertIO(admin.configuration(queueName), QueueConfiguration(originalMessageTTL, originalLockTTL, None))
+      _ = assume(queueUpdateSupported, "The test environment does not support queue update")
       _ <- admin.update(queueName, Some(originalMessageTTL + 1.minute), Some(originalLockTTL + 10.seconds))
       _ <- assertIO(
         admin.configuration(queueName),
-        QueueConfiguration(originalMessageTTL + 1.minute, originalLockTTL + 10.seconds))
+        QueueConfiguration(originalMessageTTL + 1.minute, originalLockTTL + 10.seconds, None))
     } yield ()
   }
 


### PR DESCRIPTION
This PR adds basic support for dead letter queues in the library.
 - When creating a new queue, one can optionally configure an associated dead letter queue
 - When a queue is deleted, the library deletes the dead letter queue if any. 

Solves #10 