### PR TITLE
Introducing a message handler abstraction

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,11 @@ lazy val core = crossProject(JVMPlatform)
   .in(file("core"))
   .settings(commonSettings)
   .settings(
-    name := "fs2-queues-core"
+    name := "fs2-queues-core",
+    // TODO: Remove once 0.3 is published
+    mimaBinaryIssueFilters ++= List(
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.QueueSubscriber.this")
+    )
   )
 
 lazy val testkit = crossProject(JVMPlatform)
@@ -85,6 +89,10 @@ lazy val otel4s = crossProject(JVMPlatform)
     description := "Support for metrics and tracing using otel4s",
     libraryDependencies ++= List(
       "org.typelevel" %%% "otel4s-core" % "0.7.0"
+    ),
+    // TODO: Remove once 0.3 is published
+    mimaBinaryIssueFilters ++= List(
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.otel4s.MeasuringQueueSubscriber.this")
     )
   )
   .dependsOn(core % "compile->compile;test->test")
@@ -109,6 +117,11 @@ lazy val azureServiceBus = crossProject(JVMPlatform)
     name := "fs2-queues-azure-service-bus",
     libraryDependencies ++= List(
       "com.azure" % "azure-messaging-servicebus" % "7.17.0"
+    ),
+    // TODO: Remove once 0.3 is published
+    mimaBinaryIssueFilters ++= List(
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "com.commercetools.queue.azure.servicebus.ServiceBusQueueSubscriber.this")
     )
   )
   .dependsOn(core, testkit % Test)
@@ -121,6 +134,10 @@ lazy val awsSQS = crossProject(JVMPlatform)
     name := "fs2-queues-aws-sqs",
     libraryDependencies ++= List(
       "software.amazon.awssdk" % "sqs" % "2.25.50"
+    ),
+    // TODO: Remove once 0.3 is published
+    mimaBinaryIssueFilters ++= List(
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.aws.sqs.SQSSubscriber.this")
     )
   )
   .dependsOn(core)

--- a/core/src/main/scala/com/commercetools/queue/MessageHandler.scala
+++ b/core/src/main/scala/com/commercetools/queue/MessageHandler.scala
@@ -26,10 +26,6 @@ trait MessageHandler[F[_], T, Res, D[_] <: Decision[_]] {
   def handle(msg: Message[F, T]): F[D[Res]]
 }
 
-trait ImmediateDecisionMessageHandler[F[_], T, Res] extends MessageHandler[F, T, Res, ImmediateDecision] {
-  def handle(msg: Message[F, T]): F[ImmediateDecision[Res]]
-}
-
 sealed trait Decision[+O]
 sealed trait ImmediateDecision[+O] extends Decision[O]
 object Decision {
@@ -41,7 +37,7 @@ object Decision {
 
 object MessageHandler {
   // nack on any failure except for deserialization exception
-  def default[F[_]: MonadThrow, T, O](f: Message[F, T] => F[O]): ImmediateDecisionMessageHandler[F, T, O] =
+  def default[F[_]: MonadThrow, T, O](f: Message[F, T] => F[O]): MessageHandler[F, T, O, ImmediateDecision] =
     msg =>
       f(msg).attempt.map {
         case Left(de: DeserializationException) => Decision.Fail(de, ack = true)

--- a/core/src/main/scala/com/commercetools/queue/MessageHandler.scala
+++ b/core/src/main/scala/com/commercetools/queue/MessageHandler.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 Commercetools GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.commercetools.queue
+
+import cats.MonadThrow
+import cats.syntax.applicativeError._
+import cats.syntax.functor._
+
+import scala.concurrent.duration.FiniteDuration
+
+trait MessageHandler[F[_], T, Res, D[_] <: Decision[_]] {
+  def handle(msg: Message[F, T]): F[D[Res]]
+}
+
+trait ImmediateDecisionMessageHandler[F[_], T, Res] extends MessageHandler[F, T, Res, ImmediateDecision] {
+  def handle(msg: Message[F, T]): F[ImmediateDecision[Res]]
+}
+
+sealed trait Decision[+O]
+sealed trait ImmediateDecision[+O] extends Decision[O]
+object Decision {
+  case class Ok[O](res: O) extends ImmediateDecision[O]
+  case object Drop extends ImmediateDecision[Nothing]
+  case class Fail(t: Throwable, ack: Boolean) extends ImmediateDecision[Nothing]
+  case class Reenqueue(metadata: Option[Map[String, String]], delay: Option[FiniteDuration]) extends Decision[Nothing]
+}
+
+object MessageHandler {
+  // nack on any failure except for deserialization exception
+  def default[F[_]: MonadThrow, T, O](f: Message[F, T] => F[O]): ImmediateDecisionMessageHandler[F, T, O] =
+    msg =>
+      f(msg).attempt.map {
+        case Left(de: DeserializationException) => Decision.Fail(de, ack = true)
+        case Left(t) => Decision.Fail(t, ack = false)
+        case Right(a) => Decision.Ok(a)
+      }
+}

--- a/core/src/main/scala/com/commercetools/queue/MessageHandler.scala
+++ b/core/src/main/scala/com/commercetools/queue/MessageHandler.scala
@@ -32,7 +32,8 @@ object Decision {
   case class Ok[O](res: O) extends ImmediateDecision[O]
   case object Drop extends ImmediateDecision[Nothing]
   case class Fail(t: Throwable, ack: Boolean) extends ImmediateDecision[Nothing]
-  case class Reenqueue(metadata: Option[Map[String, String]], delay: Option[FiniteDuration]) extends Decision[Nothing]
+  case class Reenqueue(metadata: Option[Map[String, String]] = None, delay: Option[FiniteDuration] = None)
+    extends Decision[Nothing]
 }
 
 object MessageHandler {

--- a/core/src/main/scala/com/commercetools/queue/QueuePublisher.scala
+++ b/core/src/main/scala/com/commercetools/queue/QueuePublisher.scala
@@ -49,3 +49,14 @@ abstract class QueuePublisher[F[_], T](implicit F: MonadCancel[F, Throwable]) {
     }
 
 }
+
+object QueuePublisher {
+
+  /**
+   * A publisher that does nothing.
+   */
+  def noOp[F[_], T](implicit F: MonadCancel[F, Throwable]) = new QueuePublisher[F, T] {
+    override def queueName: String = ""
+    override def pusher: Resource[F, QueuePusher[F, T]] = Resource.pure(QueuePusher.noOp)
+  }
+}

--- a/core/src/main/scala/com/commercetools/queue/QueuePublisher.scala
+++ b/core/src/main/scala/com/commercetools/queue/QueuePublisher.scala
@@ -55,8 +55,8 @@ object QueuePublisher {
   /**
    * A publisher that does nothing.
    */
-  def noOp[F[_], T](implicit F: MonadCancel[F, Throwable]) = new QueuePublisher[F, T] {
+  def noop[F[_], T](implicit F: MonadCancel[F, Throwable]) = new QueuePublisher[F, T] {
     override def queueName: String = ""
-    override def pusher: Resource[F, QueuePusher[F, T]] = Resource.pure(QueuePusher.noOp)
+    override def pusher: Resource[F, QueuePusher[F, T]] = Resource.pure(QueuePusher.noop)
   }
 }

--- a/core/src/main/scala/com/commercetools/queue/QueuePusher.scala
+++ b/core/src/main/scala/com/commercetools/queue/QueuePusher.scala
@@ -16,6 +16,8 @@
 
 package com.commercetools.queue
 
+import cats.Applicative
+
 import scala.concurrent.duration.FiniteDuration
 
 /**
@@ -37,4 +39,16 @@ trait QueuePusher[F[_], T] {
    */
   def push(messages: List[(T, Map[String, String])], delay: Option[FiniteDuration]): F[Unit]
 
+}
+
+object QueuePusher {
+
+  /**
+   * A pusher that does nothing.
+   */
+  def noOp[F[_], T](implicit F: Applicative[F]) = new QueuePusher[F, T] {
+    override def queueName: String = ""
+    override def push(message: T, metadata: Map[String, String], delay: Option[FiniteDuration]): F[Unit] = F.unit
+    override def push(messages: List[(T, Map[String, String])], delay: Option[FiniteDuration]): F[Unit] = F.unit
+  }
 }

--- a/core/src/main/scala/com/commercetools/queue/QueuePusher.scala
+++ b/core/src/main/scala/com/commercetools/queue/QueuePusher.scala
@@ -46,7 +46,7 @@ object QueuePusher {
   /**
    * A pusher that does nothing.
    */
-  def noOp[F[_], T](implicit F: Applicative[F]) = new QueuePusher[F, T] {
+  def noop[F[_], T](implicit F: Applicative[F]) = new QueuePusher[F, T] {
     override def queueName: String = ""
     override def push(message: T, metadata: Map[String, String], delay: Option[FiniteDuration]): F[Unit] = F.unit
     override def push(messages: List[(T, Map[String, String])], delay: Option[FiniteDuration]): F[Unit] = F.unit

--- a/core/src/main/scala/com/commercetools/queue/QueueSubscriber.scala
+++ b/core/src/main/scala/com/commercetools/queue/QueueSubscriber.scala
@@ -172,6 +172,6 @@ abstract class QueueSubscriber[F[_], T](implicit F: Concurrent[F]) {
     waitingTime: FiniteDuration
   )(handler: MessageHandler[F, T, Res, ImmediateDecision]
   ): Stream[F, Either[Throwable, Res]] =
-    process[Res](batchSize, waitingTime, QueuePublisher.noOp)((msg: Message[F, T]) =>
+    process[Res](batchSize, waitingTime, QueuePublisher.noop)((msg: Message[F, T]) =>
       handler.handle(msg).widen[Decision[Res]])
 }

--- a/core/src/main/scala/com/commercetools/queue/QueueSubscriber.scala
+++ b/core/src/main/scala/com/commercetools/queue/QueueSubscriber.scala
@@ -126,4 +126,60 @@ abstract class QueueSubscriber[F[_], T](implicit F: Concurrent[F]) {
         case Left(_) => ctx.nack()
       })
 
+  /**
+   * Processes the messages with the provided message handler.
+   * The messages are ack'ed, nack'ed or reenqueu'ed based on the decision returned from the handler.
+   * The stream emits results or errors down-stream and does not fail on business logic errors,
+   * allowing you to build error recovery logic.
+   *
+   * Messages in a batch are processed in parallel but result is emitted in order the messages were received,
+   * with the exclusion of the messages that have been reenqueu'ed and dropped.
+   */
+  final def process[Res](
+    batchSize: Int,
+    waitingTime: FiniteDuration,
+    publisherForReenqueue: QueuePublisher[F, T]
+  )(handler: MessageHandler[F, T, Res, Decision]
+  ): Stream[F, Either[Throwable, Res]] =
+    Stream
+      .resource(publisherForReenqueue.pusher)
+      .flatMap { pusher =>
+        messages(batchSize, waitingTime)
+          .parEvalMap(batchSize) { ctx =>
+            handler.handle(ctx).flatMap[Option[Either[Throwable, Res]]] {
+              case Decision.Ok(res) => ctx.ack().as(res.asRight.some)
+              case Decision.Drop => ctx.ack().as(none)
+              case Decision.Fail(t, true) => ctx.ack().as(t.asLeft.some)
+              case Decision.Fail(t, false) => ctx.nack().as(t.asLeft.some)
+              case Decision.Reenqueue(metadata, delay) =>
+                ctx.payload.flatMap(pusher.push(_, metadata.getOrElse(ctx.metadata), delay)).as(none)
+            }
+          }
+          .flattenOption
+      }
+
+  /**
+   * Processes the messages with the provided message handler.
+   * The messages are ack'ed or nack'ed based on the decision returned from the handler.
+   * The stream emits results or errors down-stream and does not fail on business logic errors,
+   * allowing you to build error recovery logic.
+   *
+   * Messages in a batch are processed in parallel but result is emitted in order the messages were received,
+   * with the exclusion of the messages that have been dropped.
+   */
+  final def processWithImmediateDecision[Res](
+    batchSize: Int,
+    waitingTime: FiniteDuration
+  )(handler: ImmediateDecisionMessageHandler[F, T, Res]
+  ): Stream[F, Either[Throwable, Res]] =
+    messages(batchSize, waitingTime)
+      .parEvalMap(batchSize) { ctx =>
+        handler.handle(ctx).flatMap[Option[Either[Throwable, Res]]] {
+          case Decision.Ok(res) => ctx.ack().as(res.asRight.some)
+          case Decision.Drop => ctx.ack().as(none)
+          case Decision.Fail(t, true) => ctx.ack().as(t.asLeft.some)
+          case Decision.Fail(t, false) => ctx.nack().as(t.asLeft.some)
+        }
+      }
+      .flattenOption
 }

--- a/core/src/main/scala/com/commercetools/queue/QueueSubscriber.scala
+++ b/core/src/main/scala/com/commercetools/queue/QueueSubscriber.scala
@@ -152,7 +152,7 @@ abstract class QueueSubscriber[F[_], T](implicit F: Concurrent[F]) {
               case Decision.Fail(t, true) => ctx.ack().as(t.asLeft.some)
               case Decision.Fail(t, false) => ctx.nack().as(t.asLeft.some)
               case Decision.Reenqueue(metadata, delay) =>
-                ctx.payload.flatMap(pusher.push(_, metadata.getOrElse(ctx.metadata), delay)).as(none)
+                ctx.payload.flatMap(pusher.push(_, ctx.metadata ++ metadata.getOrElse(Map.empty), delay)).as(none)
             }
           }
           .flattenOption

--- a/core/src/test/scala/com/commercetools/queue/testing/LockedTestMessage.scala
+++ b/core/src/test/scala/com/commercetools/queue/testing/LockedTestMessage.scala
@@ -40,7 +40,7 @@ final case class LockedTestMessage[T](
 
   override def enqueuedAt: Instant = msg.enqueuedAt
 
-  override val metadata: Map[String, String] = Map.empty
+  override val metadata: Map[String, String] = msg.metadata
 
   override def ack(): IO[Unit] =
     // done, just delete it

--- a/core/src/test/scala/com/commercetools/queue/testing/TestMessage.scala
+++ b/core/src/test/scala/com/commercetools/queue/testing/TestMessage.scala
@@ -20,7 +20,7 @@ import cats.Order
 
 import java.time.Instant
 
-final case class TestMessage[T](payload: T, enqueuedAt: Instant)
+final case class TestMessage[T](payload: T, enqueuedAt: Instant, metadata: Map[String, String] = Map.empty)
 
 object TestMessage {
 

--- a/core/src/test/scala/com/commercetools/queue/testing/TestQueue.scala
+++ b/core/src/test/scala/com/commercetools/queue/testing/TestQueue.scala
@@ -126,10 +126,14 @@ class TestQueue[T](
         state <- update(state)
       } yield delay match {
         case None =>
-          state.copy(available = state.available.addAll(messages.map(x => TestMessage(x._1, now))))
+          state.copy(available = state.available.addAll(messages.map { case (payload, metadata) =>
+            TestMessage(payload, now, metadata)
+          }))
         case Some(delay) =>
           val delayed = now.plusMillis(delay.toMillis)
-          state.copy(delayed = messages.map(x => TestMessage(x._1, delayed)) reverse_::: state.delayed)
+          state.copy(delayed = messages.map { case (payload, metadata) =>
+            TestMessage(payload, delayed, metadata)
+          } reverse_::: state.delayed)
       }
     }
 

--- a/docs/getting-started/subscribing.md
+++ b/docs/getting-started/subscribing.md
@@ -7,7 +7,7 @@ The subscriber also requires a [data deserializer][doc-deserializer] upon creati
 
 ```scala mdoc
 import cats.effect.IO
-import cats.implicits._
+import cats.syntax.all._
 import scala.concurrent.duration._
 import com.commercetools.queue.{Decision, Message, QueueClient, QueueSubscriber}
 import com.commercetools.queue.Decision._


### PR DESCRIPTION
This PR is providing a high level abstraction to consume message and dictate what to do with each of them.
This will allow to write declarative code that will make sure each message can be handled effectfuly, like:

```
       client
        .subscribe(queueName)
        .process[Int](
          batchSize = 5,
          waitingTime = 1.second,
          publisherForReenqueue = client.publish(queueName)
        )((msg: Message[IO, String]) =>
          msg.payload.attempt.flatMap {
            case Left(de: DeserializationException) => // you got something unexpected, this is a bug you should handle
              logger.error(de)("Deserialization failed.").as(Decision.Drop)
            case Right(a) => // dispatch your business logic
              serviceXyz
                .doStuffWith(a)
                .as(Decision.Ok(1)) // all good
                .handleError(e => // failed, let's retry
                  logger.error(e)("Failed doing stuff, retrying.").as(Decision.Reenqueue(delay = 1.second.some)))
          }
```

In the encoding, we distinguish between `Decision` and `ImmediateDecision`.
An `ImmediateDecision` con confirm (`Ok`, emits a Right in the output Stream), `Drop` (confirms the message and emits nothing in the output stream) or fail `Fail` (either confirm or not, emitting a `Left` in the output stream) a message. 
A `Decision` can also `Reenqueue` a message with a delay for a later re-processing, this need to also have a publisher, thus the distinction.

Closes #14.