### PR TITLE
Add Azure global settings for queue creation

### DIFF
--- a/azure/service-bus/src/main/scala/com/commercetools/queue/azure/servicebus/NewQueueSettings.scala
+++ b/azure/service-bus/src/main/scala/com/commercetools/queue/azure/servicebus/NewQueueSettings.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 Commercetools GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.commercetools.queue.azure.servicebus
+
+/** Represents a size in kibibytes (1 KiB = 1024 bytes). */
+final class Size private (val kib: Int) extends AnyVal {
+
+  /** Represents a size in mibibytes (1 MiB = 1024 KiB). */
+  def mib: Int = kib / 1024
+
+  /** Represents a size in gibibytes (1 GiB = 1024 MiB). */
+  def gib: Int = mib / 1024
+}
+
+object Size {
+
+  /**
+   * Creates the size with the given amount of KiB.
+   */
+  def kib(kib: Int): Size = new Size(kib)
+
+  /**
+   * Creates the size with the given amount of MiB.
+   * 1 MiB = 1024 Kib
+   */
+  def mib(mib: Int): Size = new Size(mib * 1024)
+
+  /**
+   * Creates the size with the given amount of GiB.
+   * 1 GiB = 1024 Mib
+   */
+  def gib(gib: Int): Size = new Size(gib * 1024 * 1024)
+
+}
+
+/**
+ * Global settings that will be used for new queues created by the library.
+ *
+ * @param partitioned Whether the new queues are partitioned (set to true if your namespace is partitioned)
+ * @param newQueueSize The max size of created queues
+ * @param maxMessageSize The max allowed size for messages
+ */
+final case class NewQueueSettings(
+  partitioned: Option[Boolean],
+  queueSize: Option[Size],
+  maxMessageSize: Option[Size])
+
+object NewQueueSettings {
+
+  /**
+   * The default settings. Default Azure defined values will be used.
+   */
+  val default: NewQueueSettings = NewQueueSettings(None, None, None)
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -109,6 +109,19 @@ lazy val azureServiceBus = crossProject(JVMPlatform)
     name := "fs2-queues-azure-service-bus",
     libraryDependencies ++= List(
       "com.azure" % "azure-messaging-servicebus" % "7.17.0"
+    ),
+    // TODO: Remove once 0.3 is published
+    mimaBinaryIssueFilters ++= List(
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "com.commercetools.queue.azure.servicebus.ServiceBusAdministration.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "com.commercetools.queue.azure.servicebus.ServiceBusClient.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "com.commercetools.queue.azure.servicebus.ServiceBusClient.unmanaged"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "com.commercetools.queue.azure.servicebus.ServiceBusClient.apply"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "com.commercetools.queue.azure.servicebus.ServiceBusClient.apply$default$3")
     )
   )
   .dependsOn(core, testkit % Test)

--- a/docs/systems/service-bus.md
+++ b/docs/systems/service-bus.md
@@ -25,4 +25,26 @@ The client is managed, meaning that it uses a conection pool that will get shut 
 
 If integrating with an existing code base where you already have builders that you would like to share, you can use the `unmanaged` variant.
 
+## Global setting for queue creation
+
+When queues are created using the library, you can define global settings at client instantiation time. These settings will be applied to any queue created with the client instance.
+
+For instance, this comes in handy when creating queues in a partitioned Premium namespace, you need to indicate that the queue is partitioned.
+
+```scala mdoc:compile-only
+import cats.effect.IO
+import com.commercetools.queue.azure.servicebus._
+import com.azure.identity.DefaultAzureCredentialBuilder
+
+val namespace = "{namespace}.servicebus.windows.net" // your namespace
+val credentials = new DefaultAzureCredentialBuilder().build() // however you want to authenticate
+
+val globalQueueSettings = NewQueueSettings.default.copy(partitioned = Some(true), queueSize = Some(Size.gib(20)))
+
+ServiceBusClient[IO](namespace, credentials, newQueueSettings = globalQueueSettings).use { client =>
+  // the queue will be partitioned and will be able to store up to 20GiB of data
+  client.administration.create("my-queue")
+}
+```
+
 [service-bus]: https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview

--- a/docs/systems/service-bus.md
+++ b/docs/systems/service-bus.md
@@ -36,14 +36,21 @@ import cats.effect.IO
 import com.commercetools.queue.azure.servicebus._
 import com.azure.identity.DefaultAzureCredentialBuilder
 
+import scala.concurrent.duration._
+
 val namespace = "{namespace}.servicebus.windows.net" // your namespace
 val credentials = new DefaultAzureCredentialBuilder().build() // however you want to authenticate
 
-val globalQueueSettings = NewQueueSettings.default.copy(partitioned = Some(true), queueSize = Some(Size.gib(20)))
+// queues will be partitioned and have a size of 20GiB
+// message size is not changed
+val globalQueueSettings =
+  NewQueueSettings.default.copy(
+    partitioned = Some(true),
+    queueSize = Some(Size.gib(20)))
 
 ServiceBusClient[IO](namespace, credentials, newQueueSettings = globalQueueSettings).use { client =>
   // the queue will be partitioned and will be able to store up to 20GiB of data
-  client.administration.create("my-queue")
+  client.administration.create("my-queue", messageTTL = 1.hour, lockTTL = 10.seconds)
 }
 ```
 


### PR DESCRIPTION
When instantiating an Azure client, user may provide global settings (related to the namespace configuration in Azure) that will be used for every queue created with the client instance.

This comes in handy when working with partitioned namespaces, which require that every queue is partitioned in it.