### PR TITLE
Allow building a SQSClient from SDK client

### DIFF
--- a/aws/sqs/src/main/scala/com/commercetools/queue/aws/sqs/SQSClient.scala
+++ b/aws/sqs/src/main/scala/com/commercetools/queue/aws/sqs/SQSClient.scala
@@ -83,4 +83,12 @@ object SQSClient {
       }
       .map(new SQSClient(_))
 
+  /**
+   * Creates an SQS client from a given instance of `SqsAsyncClient`.
+   *
+   * It is upon the caller to ensure closing of the underlying client once appropriate.
+   */
+  def fromClient[F[_]](client: SqsAsyncClient)(implicit F: Async[F]): QueueClient[F] =
+    new SQSClient(client)
+
 }

--- a/docs/systems/sqs.md
+++ b/docs/systems/sqs.md
@@ -6,7 +6,7 @@ You can create a client to service bus queues by using the [AWS SQS][sqs] module
 libraryDependencies += "com.commercetools" %% "fs2-queues-aws-sqs" % "@VERSION@"
 ```
 
-For instance you can create a managed client via a region and credentials as follows.
+For instance, you can create a managed client via a region and credentials as follows.
 
 ```scala mdoc:compile-only
 import cats.effect.IO
@@ -25,5 +25,7 @@ SQSClient[IO](region, credentials).use { client =>
 The client is managed, meaning that it uses a dedicated HTTP connection pool that will get shut down upon resource release.
 
 If integrating with an existing code base where you already have an instance of `SdkAsyncHttpClient` that you would like to share, you can pass the optional `httpClient` parameter. If passed explicitly, the client is not closed when the resource is released, and it is up to the caller to manage it.
+
+For full customization, you can supply your own instance of `SqsAsyncClient` by using `SQSClient.fromClient`. Note that this requires explicit management of the underlying client's lifecycle.
 
 [sqs]: https://aws.amazon.com/sqs/


### PR DESCRIPTION
As the implementation class is private, it can't be instantiated directly from user code. To still allow users to fully customize their SQS client, add a new smart constructor that just delegates, but has a clean signature.