### PR TITLE
Only support grpc for gcp pubsub

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -166,6 +166,18 @@ lazy val gcpPubSub = crossProject(JVMPlatform)
   .settings(commonSettings)
   .settings(
     name := "fs2-queues-gcp-pubsub",
+    // TODO: Remove once next version is published
+    mimaBinaryIssueFilters ++= List(
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "com.commercetools.queue.gcp.pubsub.PubSubAdministration.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.gcp.pubsub.PubSubClient.unmanaged"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.gcp.pubsub.PubSubClient.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "com.commercetools.queue.gcp.pubsub.PubSubClient.unmanaged$default$5"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.gcp.pubsub.PubSubPublisher.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.gcp.pubsub.PubSubPuller.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.gcp.pubsub.PubSubSubscriber.this")
+    ),
     libraryDependencies ++= List(
       "com.google.cloud" % "google-cloud-pubsub" % "1.129.3",
       "com.google.cloud" % "google-cloud-monitoring" % "3.47.0"

--- a/gcp/pubsub/integration/src/test/scala/com/commercetools/queue/pubsub/PubSubClientSuite.scala
+++ b/gcp/pubsub/integration/src/test/scala/com/commercetools/queue/pubsub/PubSubClientSuite.scala
@@ -27,6 +27,6 @@ class PubSubClientSuite extends QueueClientSuite {
   override val queueUpdateSupported = false
 
   override def client: Resource[IO, QueueClient[IO]] =
-    PubSubClient("test-project", NoCredentialsProvider.create(), endpoint = Some("http://localhost:8042"))
+    PubSubClient("test-project", NoCredentialsProvider.create(), endpoint = Some("localhost:8042"))
 
 }

--- a/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubAdministration.scala
+++ b/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubAdministration.scala
@@ -28,7 +28,6 @@ import com.google.pubsub.v1.{DeleteSubscriptionRequest, DeleteTopicRequest, Expi
 import scala.concurrent.duration._
 
 private class PubSubAdministration[F[_]](
-  useGrpc: Boolean,
   project: String,
   channelProvider: TransportChannelProvider,
   credentials: CredentialsProvider,
@@ -38,26 +37,20 @@ private class PubSubAdministration[F[_]](
 
   private val adminClient = Resource.fromAutoCloseable(F.delay {
     val builder =
-      if (useGrpc)
-        TopicAdminSettings.newBuilder()
-      else
-        TopicAdminSettings.newHttpJsonBuilder()
-    builder
-      .setCredentialsProvider(credentials)
-      .setTransportChannelProvider(channelProvider)
+      TopicAdminSettings
+        .newBuilder()
+        .setCredentialsProvider(credentials)
+        .setTransportChannelProvider(channelProvider)
     endpoint.foreach(builder.setEndpoint(_))
     TopicAdminClient.create(builder.build())
   })
 
   private val subscriptionClient = Resource.fromAutoCloseable(F.delay {
     val builder =
-      if (useGrpc)
-        SubscriptionAdminSettings.newBuilder()
-      else
-        SubscriptionAdminSettings.newHttpJsonBuilder()
-    builder
-      .setCredentialsProvider(credentials)
-      .setTransportChannelProvider(channelProvider)
+      SubscriptionAdminSettings
+        .newBuilder()
+        .setCredentialsProvider(credentials)
+        .setTransportChannelProvider(channelProvider)
     endpoint.foreach(builder.setEndpoint(_))
     SubscriptionAdminClient.create(builder.build())
   })

--- a/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubPublisher.scala
+++ b/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubPublisher.scala
@@ -20,12 +20,11 @@ import cats.effect.{Async, Resource}
 import com.commercetools.queue.{QueuePusher, Serializer, UnsealedQueuePublisher}
 import com.google.api.gax.core.CredentialsProvider
 import com.google.api.gax.rpc.TransportChannelProvider
-import com.google.cloud.pubsub.v1.stub.{GrpcPublisherStub, HttpJsonPublisherStub, PublisherStubSettings}
+import com.google.cloud.pubsub.v1.stub.{GrpcPublisherStub, PublisherStubSettings}
 import com.google.pubsub.v1.TopicName
 
 private class PubSubPublisher[F[_], T](
   val queueName: String,
-  useGrpc: Boolean,
   topicName: TopicName,
   channelProvider: TransportChannelProvider,
   credentials: CredentialsProvider,
@@ -40,19 +39,12 @@ private class PubSubPublisher[F[_], T](
       .fromAutoCloseable {
         F.blocking {
           val builder =
-            if (useGrpc)
-              PublisherStubSettings.newBuilder()
-            else
-              PublisherStubSettings.newHttpJsonBuilder()
+            PublisherStubSettings.newBuilder()
           builder
             .setCredentialsProvider(credentials)
             .setTransportChannelProvider(channelProvider)
           endpoint.foreach(builder.setEndpoint(_))
-          if (useGrpc)
-            GrpcPublisherStub.create(builder.build())
-          else
-            HttpJsonPublisherStub.create(builder.build())
-
+          GrpcPublisherStub.create(builder.build())
         }
       }
       .map(new PubSubPusher[F, T](queueName, topicName, _))


### PR DESCRIPTION
This PR is dropping http/json from the internals of gcp/pubsub, so that we'll only deal with grpc for the time being.
