### PR TITLE
Uniform waiting time in specs

### DIFF
--- a/testkit/src/main/scala/com/commercetools/queue/testkit/QueueClientSuite.scala
+++ b/testkit/src/main/scala/com/commercetools/queue/testkit/QueueClientSuite.scala
@@ -34,6 +34,7 @@ abstract class QueueClientSuite
   val messagesStatsSupported: Boolean = true
   val inFlightMessagesStatsSupported: Boolean = true
   val delayedMessagesStatsSupported: Boolean = true
+  val waitingTime: FiniteDuration = 10.seconds
 
   final val originalMessageTTL: FiniteDuration = 10.minutes
   final val originalLockTTL: FiniteDuration = 2.minutes

--- a/testkit/src/main/scala/com/commercetools/queue/testkit/QueuePublisherSuite.scala
+++ b/testkit/src/main/scala/com/commercetools/queue/testkit/QueuePublisherSuite.scala
@@ -26,7 +26,7 @@ trait QueuePublisherSuite extends CatsEffectSuite { self: QueueClientSuite =>
         .drain
       _ <- client
         .subscribe(queueName)
-        .processWithAutoAck(10, 10.seconds)(_ => count.update(_ + 1))
+        .processWithAutoAck(10, waitingTime)(_ => count.update(_ + 1))
         .take(msgs.size.toLong)
         .compile
         .drain
@@ -54,7 +54,7 @@ trait QueuePublisherSuite extends CatsEffectSuite { self: QueueClientSuite =>
               "chunk is not empty, messages are not getting delayed")
             _ <- IO.sleep(10.seconds)
             _ <- eventuallyBoolean(
-              puller.pullBatch(1, 10.seconds).map(chunk => !chunk.isEmpty),
+              puller.pullBatch(1, waitingTime).map(chunk => !chunk.isEmpty),
               "got no messages after delay")
           } yield ())
     } yield ()


### PR DESCRIPTION
Some specs require more time in CI, in other we were too generous. Here I'm extracting a default value that is really generous and will hopefully be just fine.