### PR TITLE
[ISSUE-59] Adding the possibility of pass a custom prefix for Google PubSub

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -180,6 +180,13 @@ lazy val gcpPubSub = crossProject(JVMPlatform)
     libraryDependencies ++= List(
       "com.google.cloud" % "google-cloud-pubsub" % "1.134.1",
       "com.google.cloud" % "google-cloud-monitoring" % "3.54.0"
+    ),
+    // TODO: Remove once next version is published
+    mimaBinaryIssueFilters ++= List(
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "com.commercetools.queue.gcp.pubsub.PubSubAdministration.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.gcp.pubsub.PubSubClient.unmanaged"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.gcp.pubsub.PubSubClient.apply")
     )
   )
   .dependsOn(core)

--- a/docs/systems/pubsub.md
+++ b/docs/systems/pubsub.md
@@ -15,7 +15,7 @@ import com.google.api.gax.core.GoogleCredentialsProvider
 
 val project = "my-project" // your project
 val credentials = GoogleCredentialsProvider.newBuilder().build() // however you want to authenticate
-val configs = PubSubConfig(subscriptionNamePrefix="us-central1-") // Prefix for the subscription prefix. The prefix should contain also the desired separator
+val configs = PubSubConfig(subscriptionNamePrefix=Some("us-central1-")) // Prefix for the subscription prefix. The prefix should contain also the desired separator
 
 PubSubClient[IO]( project= project, credentials= credentials,configs= configs).use { client =>
   ???
@@ -24,6 +24,21 @@ PubSubClient[IO]( project= project, credentials= credentials,configs= configs).u
 
 The client is managed, meaning that it uses a dedicated HTTP connection pool that will get shut down upon resource release.
 The client accepts a `PubSubConfig` object that allows you to configure the prefix for the subscription name. if not provided it will use the default prefix `fs2-queues-` to avoid collisions.
+You can also omit entirely the prefix by setting it to `None`.
+
+```scala mdoc:compile-only
+import cats.effect.IO
+import com.commercetools.queue.gcp.pubsub._
+import com.google.api.gax.core.GoogleCredentialsProvider
+
+val project = "my-project" // your project
+val credentials = GoogleCredentialsProvider.newBuilder().build() // however you want to authenticate
+val configs = PubSubConfig(subscriptionNamePrefix= None) 
+
+PubSubClient[IO]( project= project, credentials= credentials,configs= configs).use { client =>
+  ???
+}
+```
 
 If integrating with an existing code base where you already have an instance of `TransportChannelProvider` that you would like to share, you can use the `unmanaged` construtor.
 In this case, it is up to you to manage the channel provider life cycle.

--- a/docs/systems/pubsub.md
+++ b/docs/systems/pubsub.md
@@ -15,8 +15,9 @@ import com.google.api.gax.core.GoogleCredentialsProvider
 
 val project = "my-project" // your project
 val credentials = GoogleCredentialsProvider.newBuilder().build() // however you want to authenticate
+val configs = PubSubConfigs(subscriptionNamePrefix="us-central1-") // Prefix for the subscription prefix. The prefix should contain also the desired separator
 
-PubSubClient[IO](project, credentials).use { client =>
+PubSubClient[IO](project, credentials, configs).use { client =>
   ???
 }
 ```

--- a/docs/systems/pubsub.md
+++ b/docs/systems/pubsub.md
@@ -23,6 +23,7 @@ PubSubClient[IO]( project= project, credentials= credentials,configs= configs).u
 ```
 
 The client is managed, meaning that it uses a dedicated HTTP connection pool that will get shut down upon resource release.
+The client accepts a `PubSubConfig` object that allows you to configure the prefix for the subscription name. if not provided it will use the default prefix `fs2-queues-` to avoid collisions.
 
 If integrating with an existing code base where you already have an instance of `TransportChannelProvider` that you would like to share, you can use the `unmanaged` construtor.
 In this case, it is up to you to manage the channel provider life cycle.

--- a/docs/systems/pubsub.md
+++ b/docs/systems/pubsub.md
@@ -15,9 +15,9 @@ import com.google.api.gax.core.GoogleCredentialsProvider
 
 val project = "my-project" // your project
 val credentials = GoogleCredentialsProvider.newBuilder().build() // however you want to authenticate
-val configs = PubSubConfigs(subscriptionNamePrefix="us-central1-") // Prefix for the subscription prefix. The prefix should contain also the desired separator
+val configs = PubSubConfig(subscriptionNamePrefix="us-central1-") // Prefix for the subscription prefix. The prefix should contain also the desired separator
 
-PubSubClient[IO](project, credentials, configs).use { client =>
+PubSubClient[IO]( project= project, credentials= credentials,configs= configs).use { client =>
   ???
 }
 ```

--- a/gcp/pubsub/integration/src/test/scala/com/commercetools/queue/pubsub/PubSubClientSuite.scala
+++ b/gcp/pubsub/integration/src/test/scala/com/commercetools/queue/pubsub/PubSubClientSuite.scala
@@ -41,8 +41,8 @@ class PubSubClientSuite extends QueueClientSuite {
 
   private def config: IO[(String, CredentialsProvider, Option[String], PubSubConfig)] =
     booleanOrDefault(isEmulatorEnvVar, default = isEmulatorDefault).ifM(
-      ifTrue =
-        IO.pure(("test-project", NoCredentialsProvider.create(), Some("localhost:8042"), PubSubConfig("test-suite-"))),
+      ifTrue = IO.pure(
+        ("test-project", NoCredentialsProvider.create(), Some("localhost:8042"), PubSubConfig(Some("test-suite-")))),
       ifFalse = for {
         project <- string("GCP_PUBSUB_PROJECT")
         credentials = GoogleCredentialsProvider
@@ -52,7 +52,7 @@ class PubSubClientSuite extends QueueClientSuite {
             "https://www.googleapis.com/auth/monitoring.read" // monitoring (for fetching stats)
           ).asJava)
           .build()
-      } yield (project, credentials, None, PubSubConfig("test-suite-"))
+      } yield (project, credentials, None, PubSubConfig(Some("test-suite-")))
     )
 
   override def client: Resource[IO, QueueClient[IO]] =

--- a/gcp/pubsub/integration/src/test/scala/com/commercetools/queue/pubsub/PubSubClientSuite.scala
+++ b/gcp/pubsub/integration/src/test/scala/com/commercetools/queue/pubsub/PubSubClientSuite.scala
@@ -42,7 +42,7 @@ class PubSubClientSuite extends QueueClientSuite {
   private def config: IO[(String, CredentialsProvider, Option[String], PubSubConfig)] =
     booleanOrDefault(isEmulatorEnvVar, default = isEmulatorDefault).ifM(
       ifTrue =
-        IO.pure(("test-project", NoCredentialsProvider.create(), Some("localhost:8042"), PubSubConfig("test-suite"))),
+        IO.pure(("test-project", NoCredentialsProvider.create(), Some("localhost:8042"), PubSubConfig("test-suite-"))),
       ifFalse = for {
         project <- string("GCP_PUBSUB_PROJECT")
         credentials = GoogleCredentialsProvider
@@ -52,7 +52,7 @@ class PubSubClientSuite extends QueueClientSuite {
             "https://www.googleapis.com/auth/monitoring.read" // monitoring (for fetching stats)
           ).asJava)
           .build()
-      } yield (project, credentials, None, PubSubConfig("test-suite"))
+      } yield (project, credentials, None, PubSubConfig("test-suite-"))
     )
 
   override def client: Resource[IO, QueueClient[IO]] =

--- a/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubAdministration.scala
+++ b/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubAdministration.scala
@@ -73,7 +73,7 @@ private class PubSubAdministration[F[_]](
             Subscription
               .newBuilder()
               .setTopic(topicName.toString())
-              .setName(SubscriptionName.of(project, s"${configs.subscriptionNamePrefix}-$name").toString())
+              .setName(SubscriptionName.of(project, s"${configs.subscriptionNamePrefix}$name").toString())
               .setAckDeadlineSeconds(lockTTL.toSeconds.toInt)
               .setMessageRetentionDuration(ttl)
               // An empty expiration policy (no TTL set) ensures the subscription is never deleted
@@ -85,7 +85,7 @@ private class PubSubAdministration[F[_]](
     .adaptError(makeQueueException(_, name))
 
   override def update(name: String, messageTTL: Option[FiniteDuration], lockTTL: Option[FiniteDuration]): F[Unit] = {
-    val subscriptionName = SubscriptionName.of(project, s"${configs.subscriptionNamePrefix}-$name")
+    val subscriptionName = SubscriptionName.of(project, s"${configs.subscriptionNamePrefix}$name")
     val updateSubscriptionRequest = (messageTTL, lockTTL) match {
       case (Some(messageTTL), Some(lockTTL)) =>
         val mttl = Duration.newBuilder().setSeconds(messageTTL.toSeconds).build()
@@ -151,7 +151,7 @@ private class PubSubAdministration[F[_]](
   override def configuration(name: String): F[QueueConfiguration] =
     subscriptionClient.use { client =>
       wrapFuture[F, Subscription](F.delay {
-        val subscriptionName = SubscriptionName.of(project, s"${configs.subscriptionNamePrefix}-$name")
+        val subscriptionName = SubscriptionName.of(project, s"${configs.subscriptionNamePrefix}$name")
         client
           .getSubscriptionCallable()
           .futureCall(GetSubscriptionRequest.newBuilder().setSubscription(subscriptionName.toString()).build())
@@ -179,7 +179,7 @@ private class PubSubAdministration[F[_]](
           .futureCall(
             DeleteSubscriptionRequest
               .newBuilder()
-              .setSubscription(SubscriptionName.of(project, s"${configs.subscriptionNamePrefix}-$name").toString())
+              .setSubscription(SubscriptionName.of(project, s"${configs.subscriptionNamePrefix}$name").toString())
               .build())
       })
     }.void

--- a/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubAdministration.scala
+++ b/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubAdministration.scala
@@ -31,7 +31,8 @@ private class PubSubAdministration[F[_]](
   project: String,
   channelProvider: TransportChannelProvider,
   credentials: CredentialsProvider,
-  endpoint: Option[String]
+  endpoint: Option[String],
+  configs: PubSubConfig
 )(implicit F: Async[F])
   extends UnsealedQueueAdministration[F] {
 
@@ -72,7 +73,7 @@ private class PubSubAdministration[F[_]](
             Subscription
               .newBuilder()
               .setTopic(topicName.toString())
-              .setName(SubscriptionName.of(project, s"fs2-queue-$name").toString())
+              .setName(SubscriptionName.of(project, s"${configs.subscriptionNamePrefix}-$name").toString())
               .setAckDeadlineSeconds(lockTTL.toSeconds.toInt)
               .setMessageRetentionDuration(ttl)
               // An empty expiration policy (no TTL set) ensures the subscription is never deleted
@@ -84,7 +85,7 @@ private class PubSubAdministration[F[_]](
     .adaptError(makeQueueException(_, name))
 
   override def update(name: String, messageTTL: Option[FiniteDuration], lockTTL: Option[FiniteDuration]): F[Unit] = {
-    val subscriptionName = SubscriptionName.of(project, s"fs2-queue-$name")
+    val subscriptionName = SubscriptionName.of(project, s"${configs.subscriptionNamePrefix}-$name")
     val updateSubscriptionRequest = (messageTTL, lockTTL) match {
       case (Some(messageTTL), Some(lockTTL)) =>
         val mttl = Duration.newBuilder().setSeconds(messageTTL.toSeconds).build()
@@ -150,7 +151,7 @@ private class PubSubAdministration[F[_]](
   override def configuration(name: String): F[QueueConfiguration] =
     subscriptionClient.use { client =>
       wrapFuture[F, Subscription](F.delay {
-        val subscriptionName = SubscriptionName.of(project, s"fs2-queue-$name")
+        val subscriptionName = SubscriptionName.of(project, s"${configs.subscriptionNamePrefix}-$name")
         client
           .getSubscriptionCallable()
           .futureCall(GetSubscriptionRequest.newBuilder().setSubscription(subscriptionName.toString()).build())
@@ -178,7 +179,7 @@ private class PubSubAdministration[F[_]](
           .futureCall(
             DeleteSubscriptionRequest
               .newBuilder()
-              .setSubscription(SubscriptionName.of(project, s"fs2-queue-$name").toString())
+              .setSubscription(SubscriptionName.of(project, s"${configs.subscriptionNamePrefix}-$name").toString())
               .build())
       })
     }.void

--- a/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubClient.scala
+++ b/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubClient.scala
@@ -51,7 +51,7 @@ private class PubSubClient[F[_]: Async] private (
   override def subscribe[T: Deserializer](name: String): QueueSubscriber[F, T] =
     new PubSubSubscriber[F, T](
       name,
-      SubscriptionName.of(project, s"${configs.subscriptionNamePrefix}-$name"),
+      SubscriptionName.of(project, s"${configs.subscriptionNamePrefix}$name"),
       channelProvider,
       credentials,
       endpoint)

--- a/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubClient.scala
+++ b/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubClient.scala
@@ -40,7 +40,7 @@ private class PubSubClient[F[_]: Async] private (
   override def statistics(name: String): QueueStatistics[F] =
     new PubSubStatistics(
       name,
-      SubscriptionName.of(project, s"${configs.subscriptionNamePrefix}-$name"),
+      SubscriptionName.of(project, s"${configs.subscriptionNamePrefix}$name"),
       monitoringChannelProvider,
       credentials,
       endpoint)

--- a/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubClient.scala
+++ b/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubClient.scala
@@ -40,7 +40,7 @@ private class PubSubClient[F[_]: Async] private (
   override def statistics(name: String): QueueStatistics[F] =
     new PubSubStatistics(
       name,
-      SubscriptionName.of(project, s"${configs.subscriptionNamePrefix}$name"),
+      SubscriptionName.of(project, configs.subscriptionNamePrefix.fold(name)(_ + name)),
       monitoringChannelProvider,
       credentials,
       endpoint)
@@ -51,7 +51,7 @@ private class PubSubClient[F[_]: Async] private (
   override def subscribe[T: Deserializer](name: String): QueueSubscriber[F, T] =
     new PubSubSubscriber[F, T](
       name,
-      SubscriptionName.of(project, s"${configs.subscriptionNamePrefix}$name"),
+      SubscriptionName.of(project, configs.subscriptionNamePrefix.fold(name)(_ + name)),
       channelProvider,
       credentials,
       endpoint)

--- a/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubConfig.scala
+++ b/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubConfig.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Commercetools GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.commercetools.queue.gcp.pubsub
+
+case class PubSubConfig(subscriptionNamePrefix: String)
+
+object PubSubConfig {
+  val default: PubSubConfig = PubSubConfig("fs2-queue")
+}

--- a/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubConfig.scala
+++ b/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubConfig.scala
@@ -19,5 +19,5 @@ package com.commercetools.queue.gcp.pubsub
 case class PubSubConfig(subscriptionNamePrefix: String)
 
 object PubSubConfig {
-  val default: PubSubConfig = PubSubConfig("fs2-queue")
+  val default: PubSubConfig = PubSubConfig("fs2-queue-")
 }

--- a/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubConfig.scala
+++ b/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubConfig.scala
@@ -16,8 +16,8 @@
 
 package com.commercetools.queue.gcp.pubsub
 
-case class PubSubConfig(subscriptionNamePrefix: String)
+case class PubSubConfig(subscriptionNamePrefix: Option[String])
 
 object PubSubConfig {
-  val default: PubSubConfig = PubSubConfig("fs2-queue-")
+  val default: PubSubConfig = PubSubConfig(Some("fs2-queue-"))
 }


### PR DESCRIPTION
Like requested on [this issue](https://github.com/commercetools/fs2-queues/issues/59) I'm here to propose a way to let the user customize the prefix for Google PubSub subscriptions, while keeping the default value as it is inside the companion object of the new `PubSubConfig` case class. 
Let me know your thoughts!