### PR TITLE
Add tags/labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,17 +55,8 @@ jobs:
         if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
         run: sbt +update
 
-      - name: Install Python 3.10
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.10.15
-
-      - name: Install localstack
-        env:
-          SERVICES: sqs
-        uses: LocalStack/setup-localstack@v0.2.3
-        with:
-          image-tag: latest
+      - name: Start LocalStack
+        run: 'docker run -d -p 127.0.0.1:4566:4566 -e SERVICES=sqs --name localstack localstack/localstack:4.14'
 
       - name: Install gcloud
         uses: google-github-actions/setup-gcloud@v2

--- a/aws/sqs/integration/src/test/scala/com/commercetools/queue/sqs/SqsClientSuite.scala
+++ b/aws/sqs/integration/src/test/scala/com/commercetools/queue/sqs/SqsClientSuite.scala
@@ -56,6 +56,10 @@ class SqsClientSuite extends QueueClientSuite {
 
   override def client: Resource[IO, QueueClient[IO]] =
     config.toResource.flatMap { case (region, credentials, endpoint) =>
+      SQSClient[IO](region, credentials, endpoint = endpoint)
+    }
+  override def clientWithTags: Resource[IO, QueueClient[IO]] =
+    config.toResource.flatMap { case (region, credentials, endpoint) =>
       SQSClient[IO](region, credentials, endpoint = endpoint, config = SQSConfig(testTags))
     }
 
@@ -78,13 +82,16 @@ class SqsClientSuite extends QueueClientSuite {
         }
     }
 
-  withQueue.test("queue should have the configured tags") { queueName =>
+  withQueueWithTags.test("queue should have the configured tags on creation") { queueName =>
     assertQueueTags(queueName, testTags)
   }
 
   withQueue.test("queue should have the configured tags after update") { queueName =>
-    clientFixture().administration.update(queueName, None, None) >>
-      assertQueueTags(queueName, testTags)
+    clientWithTags
+      .use(
+        _.administration.update(queueName, None, None) >>
+          assertQueueTags(queueName, testTags)
+      )
   }
 
 }

--- a/aws/sqs/integration/src/test/scala/com/commercetools/queue/sqs/SqsClientSuite.scala
+++ b/aws/sqs/integration/src/test/scala/com/commercetools/queue/sqs/SqsClientSuite.scala
@@ -19,17 +19,21 @@ package com.commercetools.queue.sqs
 import cats.effect.{IO, Resource}
 import cats.syntax.all._
 import com.commercetools.queue.QueueClient
-import com.commercetools.queue.aws.sqs.SQSClient
+import com.commercetools.queue.aws.sqs.{SQSClient, SQSConfig}
 import com.commercetools.queue.testkit.QueueClientSuite
-import software.amazon.awssdk.auth.credentials.{AnonymousCredentialsProvider, AwsSessionCredentials, StaticCredentialsProvider}
+import software.amazon.awssdk.auth.credentials.{AnonymousCredentialsProvider, AwsCredentialsProvider, AwsSessionCredentials, StaticCredentialsProvider}
 import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import software.amazon.awssdk.services.sqs.model.{GetQueueUrlRequest, ListQueueTagsRequest}
 
 import java.net.URI
-import scala.jdk.CollectionConverters.CollectionHasAsScala
+import scala.jdk.CollectionConverters._
 
 class SqsClientSuite extends QueueClientSuite {
 
-  private def config =
+  private val testTags: Map[String, String] = Map("project" -> "fs2-queues", "env" -> "test")
+
+  private def config: IO[(Region, AwsCredentialsProvider, Option[URI])] =
     booleanOrDefault("AWS_SQS_USE_EMULATOR", default = true).ifM(
       ifTrue =
         IO.pure((Region.EU_WEST_1, AnonymousCredentialsProvider.create(), Some(new URI("http://localhost:4566")))),
@@ -52,11 +56,35 @@ class SqsClientSuite extends QueueClientSuite {
 
   override def client: Resource[IO, QueueClient[IO]] =
     config.toResource.flatMap { case (region, credentials, endpoint) =>
-      SQSClient[IO](
-        region,
-        credentials,
-        endpoint = endpoint
-      )
+      SQSClient[IO](region, credentials, endpoint = endpoint, config = SQSConfig(testTags))
     }
+
+  private def assertQueueTags(queueName: String, expectedTags: Map[String, String]): IO[Unit] =
+    config.flatMap { case (region, credentials, endpoint) =>
+      Resource
+        .fromAutoCloseable(IO.delay {
+          val builder = SqsAsyncClient.builder().region(region).credentialsProvider(credentials)
+          endpoint.foreach(builder.endpointOverride(_))
+          builder.build()
+        })
+        .use { rawClient =>
+          for {
+            urlResp <- IO.fromCompletableFuture(
+              IO.delay(rawClient.getQueueUrl(GetQueueUrlRequest.builder().queueName(queueName).build())))
+            tagsResp <- IO.fromCompletableFuture(
+              IO.delay(rawClient.listQueueTags(ListQueueTagsRequest.builder().queueUrl(urlResp.queueUrl()).build())))
+            _ <- IO(assertEquals(tagsResp.tags().asScala.toMap, expectedTags))
+          } yield ()
+        }
+    }
+
+  withQueue.test("queue should have the configured tags") { queueName =>
+    assertQueueTags(queueName, testTags)
+  }
+
+  withQueue.test("queue should have the configured tags after update") { queueName =>
+    clientFixture().administration.update(queueName, None, None) >>
+      assertQueueTags(queueName, testTags)
+  }
 
 }

--- a/aws/sqs/src/main/scala/com/commercetools/queue/aws/sqs/SQSAdministration.scala
+++ b/aws/sqs/src/main/scala/com/commercetools/queue/aws/sqs/SQSAdministration.scala
@@ -26,13 +26,19 @@ import cats.syntax.option._
 import com.commercetools.queue.aws.sqs.makeQueueException
 import com.commercetools.queue.{MalformedQueueConfigurationException, QueueConfiguration, QueueDoesNotExistException, UnsealedQueueAdministration}
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
-import software.amazon.awssdk.services.sqs.model.{CreateQueueRequest, DeleteQueueRequest, GetQueueAttributesRequest, QueueAttributeName, SetQueueAttributesRequest}
+import software.amazon.awssdk.services.sqs.model.{CreateQueueRequest, DeleteQueueRequest, GetQueueAttributesRequest, QueueAttributeName, SetQueueAttributesRequest, TagQueueRequest}
 
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
-private class SQSAdministration[F[_]](client: SqsAsyncClient, getQueueUrl: String => F[String])(implicit F: Async[F])
+private class SQSAdministration[F[_]](
+  client: SqsAsyncClient,
+  getQueueUrl: String => F[String],
+  config: SQSConfig
+)(implicit F: Async[F])
   extends UnsealedQueueAdministration[F] {
+
+  private val allTags = config.tags.asJava
 
   override def create(name: String, messageTTL: FiniteDuration, lockTTL: FiniteDuration): F[Unit] =
     F.fromCompletableFuture {
@@ -41,12 +47,12 @@ private class SQSAdministration[F[_]](client: SqsAsyncClient, getQueueUrl: Strin
           CreateQueueRequest
             .builder()
             .queueName(name)
-            .attributes(
-              Map(
-                QueueAttributeName.MESSAGE_RETENTION_PERIOD -> messageTTL.toSeconds.toString(),
-                QueueAttributeName.VISIBILITY_TIMEOUT -> lockTTL.toSeconds.toString(),
-                QueueAttributeName.RECEIVE_MESSAGE_WAIT_TIME_SECONDS -> "20" // this is meant to enable long polling https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-queue-parameters.html (see: Receive message wait time)
-              ).asJava)
+            .attributes(Map(
+              QueueAttributeName.MESSAGE_RETENTION_PERIOD -> messageTTL.toSeconds.toString(),
+              QueueAttributeName.VISIBILITY_TIMEOUT -> lockTTL.toSeconds.toString(),
+              QueueAttributeName.RECEIVE_MESSAGE_WAIT_TIME_SECONDS -> "20" // enables long polling https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-queue-parameters.html
+            ).asJava)
+            .tags(allTags)
             .build())
       }
     }.void
@@ -67,7 +73,17 @@ private class SQSAdministration[F[_]](client: SqsAsyncClient, getQueueUrl: Strin
                 ).flattenOption.asJava)
                 .build())
           }
-        }.void
+        }.void >>
+          F.fromCompletableFuture {
+            F.delay {
+              client.tagQueue(
+                TagQueueRequest
+                  .builder()
+                  .queueUrl(queueUrl)
+                  .tags(allTags)
+                  .build())
+            }
+          }.void
       }
       .adaptError(makeQueueException(_, name))
 

--- a/aws/sqs/src/main/scala/com/commercetools/queue/aws/sqs/SQSClient.scala
+++ b/aws/sqs/src/main/scala/com/commercetools/queue/aws/sqs/SQSClient.scala
@@ -28,7 +28,8 @@ import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest
 
 import java.net.URI
 
-private class SQSClient[F[_]](client: SqsAsyncClient)(implicit F: Async[F]) extends UnsealedQueueClient[F] {
+private class SQSClient[F[_]](client: SqsAsyncClient, config: SQSConfig)(implicit F: Async[F])
+  extends UnsealedQueueClient[F] {
 
   def systemName: String = "aws_sqs"
 
@@ -41,7 +42,7 @@ private class SQSClient[F[_]](client: SqsAsyncClient)(implicit F: Async[F]) exte
       .adaptError(makeQueueException(_, name))
 
   override def administration: QueueAdministration[F] =
-    new SQSAdministration(client, getQueueUrl(_))
+    new SQSAdministration(client, getQueueUrl(_), config)
 
   override def statistics(name: String): QueueStatistics[F] =
     new SQSStatistics(name, client, getQueueUrl(name))
@@ -67,7 +68,8 @@ object SQSClient {
     region: Region,
     credentials: AwsCredentialsProvider,
     endpoint: Option[URI] = None,
-    httpClient: Option[SdkAsyncHttpClient] = None
+    httpClient: Option[SdkAsyncHttpClient] = None,
+    config: SQSConfig = SQSConfig.default
   )(implicit F: Async[F]
   ): Resource[F, QueueClient[F]] =
     Resource
@@ -83,14 +85,15 @@ object SQSClient {
           builder.build()
         }
       }
-      .map(new SQSClient(_))
+      .map(new SQSClient(_, config))
 
   /**
    * Creates an SQS client from a given instance of `SqsAsyncClient`.
    *
    * It is upon the caller to ensure closing of the underlying client once appropriate.
    */
-  def fromClient[F[_]](client: SqsAsyncClient)(implicit F: Async[F]): QueueClient[F] =
-    new SQSClient(client)
+  def fromClient[F[_]](client: SqsAsyncClient, config: SQSConfig = SQSConfig.default)(implicit F: Async[F])
+    : QueueClient[F] =
+    new SQSClient(client, config)
 
 }

--- a/aws/sqs/src/main/scala/com/commercetools/queue/aws/sqs/SQSConfig.scala
+++ b/aws/sqs/src/main/scala/com/commercetools/queue/aws/sqs/SQSConfig.scala
@@ -14,17 +14,10 @@
  * limitations under the License.
  */
 
-package com.commercetools.queue.gcp.pubsub
-import com.google.pubsub.v1.SubscriptionName
+package com.commercetools.queue.aws.sqs
 
-case class PubSubConfig(
-  subscriptionNamePrefix: Option[String],
-  subscriptionNameSuffix: Option[String],
-  tags: Map[String, String] = Map.empty) {
-  def subscriptionName(project: String, name: String): SubscriptionName =
-    SubscriptionName.of(project, subscriptionNamePrefix.getOrElse("") + name + subscriptionNameSuffix.getOrElse(""))
-}
+case class SQSConfig(tags: Map[String, String] = Map.empty)
 
-object PubSubConfig {
-  val default: PubSubConfig = PubSubConfig(Some("fs2-queue-"), Some("-sub"))
+object SQSConfig {
+  val default: SQSConfig = SQSConfig()
 }

--- a/azure/service-bus/integration/src/test/scala/com/commercetools/queue/servicebus/ServiceBusClientSuite.scala
+++ b/azure/service-bus/integration/src/test/scala/com/commercetools/queue/servicebus/ServiceBusClientSuite.scala
@@ -34,4 +34,6 @@ class ServiceBusClientSuite extends QueueClientSuite {
         credentials = new AzureCliCredentialBuilder().build()
       )
     }
+
+  override def clientWithTags: Resource[IO, QueueClient[IO]] = client // Azure doesn't support this
 }

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,7 @@ import laika.config.PrettyURLs
 import laika.config.LinkConfig
 import laika.config.ApiLinks
 import laika.config.SourceLinks
+import com.typesafe.tools.mima.core._
 
 ThisBuild / tlBaseVersion := "0.10"
 
@@ -158,6 +159,12 @@ lazy val awsSQS = crossProject(JVMPlatform)
     name := "fs2-queues-aws-sqs",
     libraryDependencies ++= List(
       "software.amazon.awssdk" % "sqs" % "2.38.9"
+    ),
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.aws.sqs.SQSAdministration.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.aws.sqs.SQSClient.fromClient"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.aws.sqs.SQSClient.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.aws.sqs.SQSClient.this")
     )
   )
   .dependsOn(core)
@@ -177,6 +184,11 @@ lazy val gcpPubSub = crossProject(JVMPlatform)
     libraryDependencies ++= List(
       "com.google.cloud" % "google-cloud-pubsub" % "1.147.0",
       "com.google.cloud" % "google-cloud-monitoring" % "3.80.0"
+    ),
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.gcp.pubsub.PubSubConfig.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.gcp.pubsub.PubSubConfig.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.gcp.pubsub.PubSubConfig.this")
     )
   )
   .dependsOn(core)

--- a/build.sbt
+++ b/build.sbt
@@ -84,16 +84,12 @@ lazy val testkit = crossProject(JVMPlatform)
   .dependsOn(core)
 
 // for sqs integration test, start a localstack with sqs
+// pinned to 4.4.0 — last version under the old open-source license
 ThisBuild / githubWorkflowBuildPreamble := List(
-  WorkflowStep.Use(
-    UseRef.Public(owner = "actions", repo = "setup-python", ref = "v5"),
-    name = Some("Install Python 3.10"),
-    params = Map("python-version" -> "3.10.15")),
-  WorkflowStep.Use(
-    UseRef.Public(owner = "LocalStack", repo = "setup-localstack", ref = "v0.2.3"),
-    name = Some("Install localstack"),
-    params = Map("image-tag" -> "latest"),
-    env = Map("SERVICES" -> "sqs")
+  WorkflowStep.Run(
+    commands =
+      List("docker run -d -p 127.0.0.1:4566:4566 -e SERVICES=sqs --name localstack localstack/localstack:4.14"),
+    name = Some("Start LocalStack")
   ),
   WorkflowStep.Use(
     UseRef.Public(owner = "google-github-actions", repo = "setup-gcloud", ref = "v2"),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   localstack:
     container_name: fs2-queues-sqs
-    image: localstack/localstack:latest
+    image: localstack/localstack:4.14 # (latest version that doesn't require a license)
     ports:
       - "127.0.0.1:4566:4566"
     environment:

--- a/gcp/pubsub/integration/src/test/scala/com/commercetools/queue/pubsub/PubSubClientSuite.scala
+++ b/gcp/pubsub/integration/src/test/scala/com/commercetools/queue/pubsub/PubSubClientSuite.scala
@@ -53,7 +53,7 @@ class PubSubClientSuite extends QueueClientSuite {
           "test-project",
           NoCredentialsProvider.create(),
           Some("localhost:8042"),
-          PubSubConfig(Some("test-suite-"), Some("-sub"), testLabels))),
+          PubSubConfig(Some("test-suite-"), Some("-sub")))),
       ifFalse = for {
         project <- string("GCP_PUBSUB_PROJECT")
         credentials = GoogleCredentialsProvider
@@ -63,12 +63,17 @@ class PubSubClientSuite extends QueueClientSuite {
             "https://www.googleapis.com/auth/monitoring.read" // monitoring (for fetching stats)
           ).asJava)
           .build()
-      } yield (project, credentials, None, PubSubConfig(Some("test-suite-"), Some("-sub"), testLabels))
+      } yield (project, credentials, None, PubSubConfig(Some("test-suite-"), Some("-sub")))
     )
 
   override def client: Resource[IO, QueueClient[IO]] =
     config.toResource.flatMap { case (project, credentials, endpoint, configs) =>
       PubSubClient(project, credentials, endpoint = endpoint, configs = configs)
+    }
+
+  override def clientWithTags: Resource[IO, QueueClient[IO]] =
+    config.toResource.flatMap { case (project, credentials, endpoint, configs) =>
+      PubSubClient(project, credentials, endpoint = endpoint, configs = configs.copy(labels = testLabels))
     }
 
   private def makeChannelResource(endpoint: Option[String]): Resource[IO, GrpcTransportChannel] =
@@ -133,22 +138,15 @@ class PubSubClientSuite extends QueueClientSuite {
       }
     }
 
-  withQueue.test("topic should have the configured labels") { queueName =>
-    assertTopicLabels(queueName, testLabels)
-  }
-
-  withQueue.test("subscription should have the configured labels") { queueName =>
-    assertSubscriptionLabels(queueName, testLabels)
-  }
-
-  withQueue.test("topic should have the configured labels after update") { queueName =>
-    clientFixture().administration.update(queueName, None, None) >>
-      assertTopicLabels(queueName, testLabels)
-  }
-
-  withQueue.test("subscription should have the configured labels after update") { queueName =>
-    clientFixture().administration.update(queueName, None, None) >>
+  withQueueWithTags.test("topic/subscription should have the configured labels on creation") { queueName =>
+    assertTopicLabels(queueName, testLabels) >>
       assertSubscriptionLabels(queueName, testLabels)
   }
 
+  withQueue.test("topic should have the configured labels on update") { queueName =>
+    assume(queueUpdateSupported, "this doesn't work on the emulator")
+    clientWithTagsFixture().administration.update(queueName, None, None) >>
+      assertTopicLabels(queueName, testLabels) >>
+      assertSubscriptionLabels(queueName, testLabels)
+  }
 }

--- a/gcp/pubsub/integration/src/test/scala/com/commercetools/queue/pubsub/PubSubClientSuite.scala
+++ b/gcp/pubsub/integration/src/test/scala/com/commercetools/queue/pubsub/PubSubClientSuite.scala
@@ -21,6 +21,11 @@ import com.commercetools.queue.QueueClient
 import com.commercetools.queue.gcp.pubsub.{PubSubClient, PubSubConfig}
 import com.commercetools.queue.testkit.QueueClientSuite
 import com.google.api.gax.core.{CredentialsProvider, GoogleCredentialsProvider, NoCredentialsProvider}
+import com.google.api.gax.grpc.GrpcTransportChannel
+import com.google.api.gax.rpc.FixedTransportChannelProvider
+import com.google.cloud.pubsub.v1.{SubscriptionAdminClient, SubscriptionAdminSettings, TopicAdminClient, TopicAdminSettings}
+import com.google.pubsub.v1.{GetSubscriptionRequest, TopicName}
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
 
 import scala.concurrent.duration.{Duration, DurationInt}
 import scala.jdk.CollectionConverters._
@@ -30,10 +35,12 @@ class PubSubClientSuite extends QueueClientSuite {
   private def isEmulatorDefault = true
   private def isEmulatorEnvVar = "GCP_PUBSUB_USE_EMULATOR"
 
+  private val testLabels: Map[String, String] = Map("project" -> "fs2-queues", "env" -> "test")
+
   override val queueUpdateSupported: Boolean = false // not supported
   override val inFlightMessagesStatsSupported: Boolean = false // not supported
   override val delayedMessagesStatsSupported: Boolean = false // not supported
-  override val messagesStatsSupported: Boolean = // // not supported in the emulator
+  override val messagesStatsSupported: Boolean = // not supported in the emulator
     !sys.env.get(isEmulatorEnvVar).map(_.toBoolean).getOrElse(isEmulatorDefault)
 
   // stats require a long time to be propagated and be available
@@ -46,7 +53,7 @@ class PubSubClientSuite extends QueueClientSuite {
           "test-project",
           NoCredentialsProvider.create(),
           Some("localhost:8042"),
-          PubSubConfig(Some("test-suite-"), Some("-sub")))),
+          PubSubConfig(Some("test-suite-"), Some("-sub"), testLabels))),
       ifFalse = for {
         project <- string("GCP_PUBSUB_PROJECT")
         credentials = GoogleCredentialsProvider
@@ -56,12 +63,92 @@ class PubSubClientSuite extends QueueClientSuite {
             "https://www.googleapis.com/auth/monitoring.read" // monitoring (for fetching stats)
           ).asJava)
           .build()
-      } yield (project, credentials, None, PubSubConfig(Some("test-suite-"), Some("-sub")))
+      } yield (project, credentials, None, PubSubConfig(Some("test-suite-"), Some("-sub"), testLabels))
     )
 
   override def client: Resource[IO, QueueClient[IO]] =
     config.toResource.flatMap { case (project, credentials, endpoint, configs) =>
       PubSubClient(project, credentials, endpoint = endpoint, configs = configs)
     }
+
+  private def makeChannelResource(endpoint: Option[String]): Resource[IO, GrpcTransportChannel] =
+    Resource.fromAutoCloseable(IO.blocking {
+      val builder = endpoint match {
+        case Some(e) => NettyChannelBuilder.forTarget(e).usePlaintext()
+        case None =>
+          import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts
+          NettyChannelBuilder.forTarget("pubsub.googleapis.com:443").sslContext(GrpcSslContexts.forClient().build())
+      }
+      GrpcTransportChannel.create(builder.build())
+    })
+
+  private def assertTopicLabels(
+    queueName: String,
+    expectedLabels: Map[String, String]
+  ): IO[Unit] =
+    config.flatMap { case (project, credentials, endpoint, _) =>
+      makeChannelResource(endpoint).use { channel =>
+        val channelProvider = FixedTransportChannelProvider.create(channel)
+        Resource
+          .fromAutoCloseable(IO.blocking {
+            val builder = TopicAdminSettings
+              .newBuilder()
+              .setCredentialsProvider(credentials)
+              .setTransportChannelProvider(channelProvider)
+            endpoint.foreach(builder.setEndpoint(_))
+            TopicAdminClient.create(builder.build())
+          })
+          .use { topicClient =>
+            IO.blocking(topicClient.getTopic(TopicName.of(project, queueName).toString()))
+              .map(topic => assertEquals(topic.getLabelsMap().asScala.toMap, expectedLabels))
+          }
+      }
+    }
+
+  private def assertSubscriptionLabels(
+    queueName: String,
+    expectedLabels: Map[String, String]
+  ): IO[Unit] =
+    config.flatMap { case (project, credentials, endpoint, configs) =>
+      makeChannelResource(endpoint).use { channel =>
+        val channelProvider = FixedTransportChannelProvider.create(channel)
+        Resource
+          .fromAutoCloseable(IO.blocking {
+            val builder = SubscriptionAdminSettings
+              .newBuilder()
+              .setCredentialsProvider(credentials)
+              .setTransportChannelProvider(channelProvider)
+            endpoint.foreach(builder.setEndpoint(_))
+            SubscriptionAdminClient.create(builder.build())
+          })
+          .use { subClient =>
+            IO.blocking(
+              subClient.getSubscription(
+                GetSubscriptionRequest
+                  .newBuilder()
+                  .setSubscription(configs.subscriptionName(project, queueName).toString())
+                  .build()))
+              .map(sub => assertEquals(sub.getLabelsMap().asScala.toMap, expectedLabels))
+          }
+      }
+    }
+
+  withQueue.test("topic should have the configured labels") { queueName =>
+    assertTopicLabels(queueName, testLabels)
+  }
+
+  withQueue.test("subscription should have the configured labels") { queueName =>
+    assertSubscriptionLabels(queueName, testLabels)
+  }
+
+  withQueue.test("topic should have the configured labels after update") { queueName =>
+    clientFixture().administration.update(queueName, None, None) >>
+      assertTopicLabels(queueName, testLabels)
+  }
+
+  withQueue.test("subscription should have the configured labels after update") { queueName =>
+    clientFixture().administration.update(queueName, None, None) >>
+      assertSubscriptionLabels(queueName, testLabels)
+  }
 
 }

--- a/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubAdministration.scala
+++ b/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubAdministration.scala
@@ -64,7 +64,7 @@ private class PubSubAdministration[F[_]](
   override def create(name: String, messageTTL: FiniteDuration, lockTTL: FiniteDuration): F[Unit] = {
     val topicName = TopicName.of(project, name)
     val ttl = Duration.newBuilder().setSeconds(messageTTL.toSeconds).build()
-    val allLabels = configs.tags.asJava
+    val allLabels = configs.labels.asJava
     adminClient.use { client =>
       wrapFuture(F.delay {
         client
@@ -103,10 +103,10 @@ private class PubSubAdministration[F[_]](
   override def update(name: String, messageTTL: Option[FiniteDuration], lockTTL: Option[FiniteDuration]): F[Unit] = {
     val topicName = TopicName.of(project, name)
     val subscriptionName = configs.subscriptionName(project, name)
-    val allLabels = configs.tags.asJava
+    val allLabels = configs.labels.asJava
 
     val topicUpdate =
-      if (configs.tags.nonEmpty)
+      if (configs.labels.nonEmpty)
         adminClient.use { client =>
           wrapFuture(F.delay {
             client
@@ -130,7 +130,7 @@ private class PubSubAdministration[F[_]](
     val subPaths = List(
       messageTTL.as("message_retention_duration"),
       lockTTL.as("ack_deadline_seconds"),
-      Option.when(configs.tags.nonEmpty)("labels")
+      Option.when(configs.labels.nonEmpty)("labels")
     ).flatten
 
     val subUpdate =
@@ -139,7 +139,7 @@ private class PubSubAdministration[F[_]](
         messageTTL.foreach(mttl =>
           subBuilder.setMessageRetentionDuration(Duration.newBuilder().setSeconds(mttl.toSeconds).build()))
         lockTTL.foreach(lttl => subBuilder.setAckDeadlineSeconds(lttl.toSeconds.toInt))
-        if (configs.tags.nonEmpty) { val _ = subBuilder.putAllLabels(allLabels) }
+        if (configs.labels.nonEmpty) { val _ = subBuilder.putAllLabels(allLabels) }
         subscriptionClient.use { client =>
           wrapFuture(F.delay {
             client

--- a/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubAdministration.scala
+++ b/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubAdministration.scala
@@ -24,9 +24,10 @@ import com.google.api.gax.core.{CredentialsProvider, ExecutorProvider}
 import com.google.api.gax.rpc.{AlreadyExistsException, NotFoundException, TransportChannelProvider}
 import com.google.cloud.pubsub.v1.{SubscriptionAdminClient, SubscriptionAdminSettings, TopicAdminClient, TopicAdminSettings}
 import com.google.protobuf.{Duration, FieldMask}
-import com.google.pubsub.v1.{DeleteSubscriptionRequest, DeleteTopicRequest, ExpirationPolicy, GetSubscriptionRequest, GetTopicRequest, Subscription, Topic, TopicName, UpdateSubscriptionRequest}
+import com.google.pubsub.v1.{DeleteSubscriptionRequest, DeleteTopicRequest, ExpirationPolicy, GetSubscriptionRequest, GetTopicRequest, Subscription, Topic, TopicName, UpdateSubscriptionRequest, UpdateTopicRequest}
 
 import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
 
 private class PubSubAdministration[F[_]](
   project: String,
@@ -63,11 +64,18 @@ private class PubSubAdministration[F[_]](
   override def create(name: String, messageTTL: FiniteDuration, lockTTL: FiniteDuration): F[Unit] = {
     val topicName = TopicName.of(project, name)
     val ttl = Duration.newBuilder().setSeconds(messageTTL.toSeconds).build()
+    val allLabels = configs.tags.asJava
     adminClient.use { client =>
       wrapFuture(F.delay {
         client
           .createTopicCallable()
-          .futureCall(Topic.newBuilder().setName(topicName.toString()).build())
+          .futureCall(
+            Topic
+              .newBuilder()
+              .setName(topicName.toString)
+              .putAllLabels(allLabels)
+              .build()
+          )
       }).void.recover {
         // ignore and continue so that the subscription can be created if it's not there yet
         case _: AlreadyExistsException => ()
@@ -79,12 +87,13 @@ private class PubSubAdministration[F[_]](
           .futureCall(
             Subscription
               .newBuilder()
-              .setTopic(topicName.toString())
-              .setName(configs.subscriptionName(project, name).toString())
+              .setTopic(topicName.toString)
+              .setName(configs.subscriptionName(project, name).toString)
               .setAckDeadlineSeconds(lockTTL.toSeconds.toInt)
               .setMessageRetentionDuration(ttl)
               // An empty expiration policy (no TTL set) ensures the subscription is never deleted
               .setExpirationPolicy(ExpirationPolicy.newBuilder().build())
+              .putAllLabels(allLabels)
               .build())
       })
     }.void
@@ -92,67 +101,60 @@ private class PubSubAdministration[F[_]](
     .adaptError(makeQueueException(_, name))
 
   override def update(name: String, messageTTL: Option[FiniteDuration], lockTTL: Option[FiniteDuration]): F[Unit] = {
+    val topicName = TopicName.of(project, name)
     val subscriptionName = configs.subscriptionName(project, name)
-    val updateSubscriptionRequest = (messageTTL, lockTTL) match {
-      case (Some(messageTTL), Some(lockTTL)) =>
-        val mttl = Duration.newBuilder().setSeconds(messageTTL.toSeconds).build()
+    val allLabels = configs.tags.asJava
 
-        Some(
-          UpdateSubscriptionRequest
-            .newBuilder()
-            .setSubscription(
-              Subscription
-                .newBuilder()
-                .setName(subscriptionName.toString())
-                .setMessageRetentionDuration(mttl)
-                .setAckDeadlineSeconds(lockTTL.toSeconds.toInt)
-                .build())
-            .setUpdateMask(
-              FieldMask
-                .newBuilder()
-                .addPaths("message_retention_duration")
-                .addPaths("ack_deadline_seconds")
-                .build())
-            .build())
-      case (Some(messageTTL), None) =>
-        val mttl = Duration.newBuilder().setSeconds(messageTTL.toSeconds).build()
-        Some(
-          UpdateSubscriptionRequest
-            .newBuilder()
-            .setSubscription(
-              Subscription
-                .newBuilder()
-                .setName(subscriptionName.toString())
-                .setMessageRetentionDuration(mttl)
-                .build())
-            .setUpdateMask(FieldMask
-              .newBuilder()
-              .addPaths("message_retention_duration")
-              .build())
-            .build())
-      case (None, Some(lockTTL)) =>
-        Some(
-          UpdateSubscriptionRequest
-            .newBuilder()
-            .setSubscription(
-              Subscription
-                .newBuilder()
-                .setName(subscriptionName.toString())
-                .setAckDeadlineSeconds(lockTTL.toSeconds.toInt)
-                .build())
-            .setUpdateMask(FieldMask
-              .newBuilder()
-              .addPaths("ack_deadline_seconds")
-              .build())
-            .build())
-      case (None, None) =>
-        None
-    }
-    updateSubscriptionRequest.traverse_ { req =>
-      subscriptionClient.use { client =>
-        wrapFuture(F.delay(client.updateSubscriptionCallable().futureCall(req)))
-      }
-    }
+    val topicUpdate =
+      if (configs.tags.nonEmpty)
+        adminClient.use { client =>
+          wrapFuture(F.delay {
+            client
+              .updateTopicCallable()
+              .futureCall(
+                UpdateTopicRequest
+                  .newBuilder()
+                  .setTopic(
+                    Topic
+                      .newBuilder()
+                      .setName(topicName.toString)
+                      .putAllLabels(allLabels)
+                      .build()
+                  )
+                  .setUpdateMask(FieldMask.newBuilder().addPaths("labels").build())
+                  .build())
+          })
+        }.void
+      else F.unit
+
+    val subPaths = List(
+      messageTTL.as("message_retention_duration"),
+      lockTTL.as("ack_deadline_seconds"),
+      Option.when(configs.tags.nonEmpty)("labels")
+    ).flatten
+
+    val subUpdate =
+      if (subPaths.nonEmpty) {
+        val subBuilder = Subscription.newBuilder().setName(subscriptionName.toString)
+        messageTTL.foreach(mttl =>
+          subBuilder.setMessageRetentionDuration(Duration.newBuilder().setSeconds(mttl.toSeconds).build()))
+        lockTTL.foreach(lttl => subBuilder.setAckDeadlineSeconds(lttl.toSeconds.toInt))
+        if (configs.tags.nonEmpty) { val _ = subBuilder.putAllLabels(allLabels) }
+        subscriptionClient.use { client =>
+          wrapFuture(F.delay {
+            client
+              .updateSubscriptionCallable()
+              .futureCall(
+                UpdateSubscriptionRequest
+                  .newBuilder()
+                  .setSubscription(subBuilder.build())
+                  .setUpdateMask(FieldMask.newBuilder().addAllPaths(subPaths.asJava).build())
+                  .build())
+          })
+        }.void
+      } else F.unit
+
+    topicUpdate >> subUpdate
   }
 
   override def configuration(name: String): F[QueueConfiguration] =

--- a/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubConfig.scala
+++ b/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubConfig.scala
@@ -20,7 +20,7 @@ import com.google.pubsub.v1.SubscriptionName
 case class PubSubConfig(
   subscriptionNamePrefix: Option[String],
   subscriptionNameSuffix: Option[String],
-  tags: Map[String, String] = Map.empty) {
+  labels: Map[String, String] = Map.empty) {
   def subscriptionName(project: String, name: String): SubscriptionName =
     SubscriptionName.of(project, subscriptionNamePrefix.getOrElse("") + name + subscriptionNameSuffix.getOrElse(""))
 }

--- a/testkit/src/main/scala/com/commercetools/queue/testkit/QueueClientSuite.scala
+++ b/testkit/src/main/scala/com/commercetools/queue/testkit/QueueClientSuite.scala
@@ -41,8 +41,12 @@ abstract class QueueClientSuite
 
   /** Provide a way to acquire a queue client for the provider under test. */
   def client: Resource[IO, QueueClient[IO]]
+  def clientWithTags: Resource[IO, QueueClient[IO]]
 
   final val clientFixture: IOFixture[QueueClient[IO]] = ResourceSuiteLocalFixture("queue-client", client)
+  final val clientWithTagsFixture: IOFixture[QueueClient[IO]] =
+    ResourceSuiteLocalFixture("queue-client-with-tags", clientWithTags)
+
   final lazy val withQueue: SyncIO[FunFixture[String]] =
     ResourceFunFixture(
       Resource.make(
@@ -52,7 +56,27 @@ abstract class QueueClientSuite
             clientFixture().administration
               .create(queueName, originalMessageTTL, originalLockTTL)
           })(queueName => clientFixture().administration.delete(queueName)))
-  final override def munitFixtures: List[IOFixture[QueueClient[IO]]] = List(clientFixture)
+  final lazy val withQueueWithLabels: SyncIO[FunFixture[String]] =
+    ResourceFunFixture(
+      Resource.make(
+        IO.randomUUID
+          .map(uuid => s"queue-$uuid")
+          .flatTap { queueName =>
+            clientFixture().administration
+              .create(queueName, originalMessageTTL, originalLockTTL)
+          })(queueName => clientFixture().administration.delete(queueName)))
+
+  final lazy val withQueueWithTags: SyncIO[FunFixture[String]] =
+    ResourceFunFixture(
+      Resource.make(
+        IO.randomUUID
+          .map(uuid => s"queue-$uuid")
+          .flatTap { queueName =>
+            clientWithTagsFixture().administration
+              .create(queueName, originalMessageTTL, originalLockTTL)
+          })(queueName => clientWithTagsFixture().administration.delete(queueName)))
+
+  final override def munitFixtures: List[IOFixture[QueueClient[IO]]] = List(clientFixture, clientWithTagsFixture)
 
   final def randomMessages(n: Int): IO[List[(String, Map[String, String])]] = for {
     random <- Random.scalaUtilRandom[IO]


### PR DESCRIPTION
This is adding support for adding labels/tags to each queue, topic and subscription. This can be useful for various reason. For now we're only supporting the bare minimum (a `Map[String, String]`).
- In AWS SQS, tags are supported
- In GCP PubSub, labels are supported
- in Azure, nothing due to a lack of alternatives.

Both creation and updates operation are supported. Currently, tags/labels are global to all the resources managed by the lib.