### PR TITLE
Fix exception on empty attributes/tags

### DIFF
--- a/aws/sqs/src/main/scala/com/commercetools/queue/aws/sqs/SQSAdministration.scala
+++ b/aws/sqs/src/main/scala/com/commercetools/queue/aws/sqs/SQSAdministration.scala
@@ -43,49 +43,54 @@ private class SQSAdministration[F[_]](
   override def create(name: String, messageTTL: FiniteDuration, lockTTL: FiniteDuration): F[Unit] =
     F.fromCompletableFuture {
       F.delay {
-        client.createQueue(
-          CreateQueueRequest
-            .builder()
-            .queueName(name)
-            .attributes(Map(
-              QueueAttributeName.MESSAGE_RETENTION_PERIOD -> messageTTL.toSeconds.toString(),
-              QueueAttributeName.VISIBILITY_TIMEOUT -> lockTTL.toSeconds.toString(),
-              QueueAttributeName.RECEIVE_MESSAGE_WAIT_TIME_SECONDS -> "20" // enables long polling https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-queue-parameters.html
-            ).asJava)
-            .tags(allTags)
-            .build())
+        val req = CreateQueueRequest
+          .builder()
+          .queueName(name)
+          .attributes(Map(
+            QueueAttributeName.MESSAGE_RETENTION_PERIOD -> messageTTL.toSeconds.toString(),
+            QueueAttributeName.VISIBILITY_TIMEOUT -> lockTTL.toSeconds.toString(),
+            QueueAttributeName.RECEIVE_MESSAGE_WAIT_TIME_SECONDS -> "20" // enables long polling https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-queue-parameters.html
+          ).asJava)
+        val taggedReq = if (config.tags.nonEmpty) req.tags(allTags) else req
+        client.createQueue(taggedReq.build())
       }
     }.void
       .adaptError(makeQueueException(_, name))
 
-  override def update(name: String, messageTTL: Option[FiniteDuration], lockTTL: Option[FiniteDuration]): F[Unit] =
+  override def update(name: String, messageTTL: Option[FiniteDuration], lockTTL: Option[FiniteDuration]): F[Unit] = {
+    val attributes = Map(
+      QueueAttributeName.MESSAGE_RETENTION_PERIOD -> messageTTL.map(_.toSeconds.toString()),
+      QueueAttributeName.VISIBILITY_TIMEOUT -> lockTTL.map(_.toSeconds.toString())
+    ).flattenOption
     getQueueUrl(name)
       .flatMap { queueUrl =>
-        F.fromCompletableFuture {
-          F.delay {
-            client.setQueueAttributes(
-              SetQueueAttributesRequest
-                .builder()
-                .queueUrl(queueUrl)
-                .attributes(Map(
-                  QueueAttributeName.MESSAGE_RETENTION_PERIOD -> messageTTL.map(_.toSeconds.toString()),
-                  QueueAttributeName.VISIBILITY_TIMEOUT -> lockTTL.map(_.toSeconds.toString())
-                ).flattenOption.asJava)
-                .build())
-          }
-        }.void >>
+        F.whenA(attributes.nonEmpty) {
           F.fromCompletableFuture {
             F.delay {
-              client.tagQueue(
-                TagQueueRequest
+              client.setQueueAttributes(
+                SetQueueAttributesRequest
                   .builder()
                   .queueUrl(queueUrl)
-                  .tags(allTags)
+                  .attributes(attributes.asJava)
                   .build())
             }
           }.void
+        } >>
+          F.whenA(config.tags.nonEmpty) {
+            F.fromCompletableFuture {
+              F.delay {
+                client.tagQueue(
+                  TagQueueRequest
+                    .builder()
+                    .queueUrl(queueUrl)
+                    .tags(allTags)
+                    .build())
+              }
+            }.void
+          }
       }
       .adaptError(makeQueueException(_, name))
+  }
 
   override def configuration(name: String): F[QueueConfiguration] =
     getQueueUrl(name)

--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,8 @@ import laika.config.PrettyURLs
 import laika.config.LinkConfig
 import laika.config.ApiLinks
 import laika.config.SourceLinks
-import com.typesafe.tools.mima.core._
 
-ThisBuild / tlBaseVersion := "0.10"
+ThisBuild / tlBaseVersion := "0.11"
 
 ThisBuild / organization := "com.commercetools"
 ThisBuild / organizationName := "Commercetools GmbH"
@@ -159,12 +158,6 @@ lazy val awsSQS = crossProject(JVMPlatform)
     name := "fs2-queues-aws-sqs",
     libraryDependencies ++= List(
       "software.amazon.awssdk" % "sqs" % "2.42.39"
-    ),
-    mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.aws.sqs.SQSAdministration.this"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.aws.sqs.SQSClient.fromClient"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.aws.sqs.SQSClient.apply"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.aws.sqs.SQSClient.this")
     )
   )
   .dependsOn(core)
@@ -184,11 +177,6 @@ lazy val gcpPubSub = crossProject(JVMPlatform)
     libraryDependencies ++= List(
       "com.google.cloud" % "google-cloud-pubsub" % "1.150.1",
       "com.google.cloud" % "google-cloud-monitoring" % "3.92.0"
-    ),
-    mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.gcp.pubsub.PubSubConfig.apply"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.gcp.pubsub.PubSubConfig.copy"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.gcp.pubsub.PubSubConfig.this")
     )
   )
   .dependsOn(core)


### PR DESCRIPTION
As it turned out, SQS enforces some invariants whereas the emulator is more lenient.

This PR is fixing an exception that is raised when providing an empty `tags` or `attributes`.