### PR TITLE
Allow to specify the lockTTL on subscribe

### DIFF
--- a/aws/sqs/src/main/scala/com/commercetools/queue/aws/sqs/SQSClient.scala
+++ b/aws/sqs/src/main/scala/com/commercetools/queue/aws/sqs/SQSClient.scala
@@ -27,6 +27,7 @@ import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest
 
 import java.net.URI
+import scala.concurrent.duration.FiniteDuration
 
 private class SQSClient[F[_]](client: SqsAsyncClient, config: SQSConfig)(implicit F: Async[F])
   extends UnsealedQueueClient[F] {
@@ -50,8 +51,8 @@ private class SQSClient[F[_]](client: SqsAsyncClient, config: SQSConfig)(implici
   override def publish[T: Serializer](name: String): QueuePublisher[F, T] =
     new SQSPublisher(name, client, getQueueUrl(name))
 
-  override def subscribe[T: Deserializer](name: String): QueueSubscriber[F, T] =
-    new SQSSubscriber[F, T](name, client, getQueueUrl(name))
+  override def subscribe[T: Deserializer](name: String, lockTTL: Option[FiniteDuration] = None): QueueSubscriber[F, T] =
+    new SQSSubscriber[F, T](name, client, getQueueUrl(name), lockTTL)
 
 }
 

--- a/aws/sqs/src/main/scala/com/commercetools/queue/aws/sqs/SQSSubscriber.scala
+++ b/aws/sqs/src/main/scala/com/commercetools/queue/aws/sqs/SQSSubscriber.scala
@@ -16,6 +16,7 @@
 
 package com.commercetools.queue.aws.sqs
 
+import cats.data.OptionT
 import cats.effect.{Async, Resource}
 import cats.syntax.all._
 import com.commercetools.queue.{Deserializer, QueuePuller, UnsealedQueueSubscriber}
@@ -51,7 +52,7 @@ private class SQSSubscriber[F[_], T](
     Resource.eval {
       for {
         queueUrl <- getQueueUrl
-        lockTTLSeconds <- lockTTL.map(ttl => F.pure(ttl.toSeconds.toInt)).getOrElse(getLockTTL(queueUrl))
+        lockTTLSeconds <- OptionT.fromOption(lockTTL).map(_.toSeconds.toInt).getOrElseF(getLockTTL(queueUrl))
       } yield new SQSPuller(queueName, client, queueUrl, lockTTLSeconds)
     }
 

--- a/aws/sqs/src/main/scala/com/commercetools/queue/aws/sqs/SQSSubscriber.scala
+++ b/aws/sqs/src/main/scala/com/commercetools/queue/aws/sqs/SQSSubscriber.scala
@@ -22,10 +22,13 @@ import com.commercetools.queue.{Deserializer, QueuePuller, UnsealedQueueSubscrib
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.{GetQueueAttributesRequest, QueueAttributeName}
 
+import scala.concurrent.duration.FiniteDuration
+
 private class SQSSubscriber[F[_], T](
   val queueName: String,
   client: SqsAsyncClient,
-  getQueueUrl: F[String]
+  getQueueUrl: F[String],
+  lockTTL: Option[FiniteDuration]
 )(implicit
   F: Async[F],
   deserializer: Deserializer[T])
@@ -48,8 +51,8 @@ private class SQSSubscriber[F[_], T](
     Resource.eval {
       for {
         queueUrl <- getQueueUrl
-        lockTTL <- getLockTTL(queueUrl)
-      } yield new SQSPuller(queueName, client, queueUrl, lockTTL)
+        lockTTLSeconds <- lockTTL.map(ttl => F.pure(ttl.toSeconds.toInt)).getOrElse(getLockTTL(queueUrl))
+      } yield new SQSPuller(queueName, client, queueUrl, lockTTLSeconds)
     }
 
 }

--- a/azure/service-bus/src/main/scala/com/commercetools/queue/azure/servicebus/ServiceBusClient.scala
+++ b/azure/service-bus/src/main/scala/com/commercetools/queue/azure/servicebus/ServiceBusClient.scala
@@ -23,6 +23,8 @@ import com.azure.messaging.servicebus.ServiceBusClientBuilder
 import com.azure.messaging.servicebus.administration.ServiceBusAdministrationClientBuilder
 import com.commercetools.queue.{Deserializer, QueueAdministration, QueueClient, QueuePublisher, QueueStatistics, QueueSubscriber, Serializer, UnsealedQueueClient}
 
+import scala.concurrent.duration.FiniteDuration
+
 private class ServiceBusClient[F[_]] private (
   clientBuilder: ServiceBusClientBuilder,
   adminBuilder: ServiceBusAdministrationClientBuilder,
@@ -41,8 +43,8 @@ private class ServiceBusClient[F[_]] private (
   override def publish[T: Serializer](name: String): QueuePublisher[F, T] =
     new ServiceBusQueuePublisher[F, T](name, clientBuilder)
 
-  override def subscribe[T: Deserializer](name: String): QueueSubscriber[F, T] =
-    new ServiceBusQueueSubscriber[F, T](name, clientBuilder)
+  override def subscribe[T: Deserializer](name: String, lockTTL: Option[FiniteDuration] = None): QueueSubscriber[F, T] =
+    new ServiceBusQueueSubscriber[F, T](name, clientBuilder, lockTTL)
 
 }
 

--- a/azure/service-bus/src/main/scala/com/commercetools/queue/azure/servicebus/ServiceBusMessageContext.scala
+++ b/azure/service-bus/src/main/scala/com/commercetools/queue/azure/servicebus/ServiceBusMessageContext.scala
@@ -16,6 +16,7 @@
 
 package com.commercetools.queue.azure.servicebus
 
+import cats.data.OptionT
 import cats.effect.Async
 import cats.syntax.functor._
 import com.azure.messaging.servicebus.{ServiceBusReceivedMessage, ServiceBusReceiverClient}
@@ -49,9 +50,10 @@ private class ServiceBusMessageContext[F[_], T](
     F.blocking(receiver.abandon(underlying)).void
 
   override def extendLock(): F[Unit] =
-    lockTTL
-      .map(ttl => F.blocking(receiver.renewMessageLock(underlying, JDuration.ofNanos(ttl.toNanos), null)).void)
-      .getOrElse(F.blocking(receiver.renewMessageLock(underlying)).void)
+    OptionT
+      .fromOption(lockTTL)
+      .semiflatMap(ttl => F.blocking(receiver.renewMessageLock(underlying, JDuration.ofNanos(ttl.toNanos), null)).void)
+      .getOrElseF(F.blocking(receiver.renewMessageLock(underlying)).void)
 
   override val messageId: MessageId = MessageId(underlying.getMessageId())
 

--- a/azure/service-bus/src/main/scala/com/commercetools/queue/azure/servicebus/ServiceBusMessageContext.scala
+++ b/azure/service-bus/src/main/scala/com/commercetools/queue/azure/servicebus/ServiceBusMessageContext.scala
@@ -21,13 +21,15 @@ import cats.syntax.functor._
 import com.azure.messaging.servicebus.{ServiceBusReceivedMessage, ServiceBusReceiverClient}
 import com.commercetools.queue.{MessageId, UnsealedMessageContext}
 
-import java.time.Instant
+import java.time.{Duration => JDuration, Instant}
+import scala.concurrent.duration.FiniteDuration
 import scala.jdk.CollectionConverters.MapHasAsScala
 
 private class ServiceBusMessageContext[F[_], T](
   val payload: F[T],
   val underlying: ServiceBusReceivedMessage,
-  receiver: ServiceBusReceiverClient
+  receiver: ServiceBusReceiverClient,
+  lockTTL: Option[FiniteDuration]
 )(implicit F: Async[F])
   extends UnsealedMessageContext[F, T] {
 
@@ -47,7 +49,9 @@ private class ServiceBusMessageContext[F[_], T](
     F.blocking(receiver.abandon(underlying)).void
 
   override def extendLock(): F[Unit] =
-    F.blocking(receiver.renewMessageLock(underlying)).void
+    lockTTL
+      .map(ttl => F.blocking(receiver.renewMessageLock(underlying, JDuration.ofNanos(ttl.toNanos), null)).void)
+      .getOrElse(F.blocking(receiver.renewMessageLock(underlying)).void)
 
   override val messageId: MessageId = MessageId(underlying.getMessageId())
 

--- a/azure/service-bus/src/main/scala/com/commercetools/queue/azure/servicebus/ServiceBusPuller.scala
+++ b/azure/service-bus/src/main/scala/com/commercetools/queue/azure/servicebus/ServiceBusPuller.scala
@@ -29,7 +29,8 @@ import scala.jdk.CollectionConverters._
 
 private class ServiceBusPuller[F[_], Data](
   val queueName: String,
-  receiver: ServiceBusReceiverClient
+  receiver: ServiceBusReceiverClient,
+  lockTTL: Option[FiniteDuration]
 )(implicit
   F: Async[F],
   deserializer: Deserializer[Data])
@@ -54,7 +55,7 @@ private class ServiceBusPuller[F[_], Data](
               .deserializeF(sbMessage.getBody().toString())
               .memoize
               .map { data =>
-                new ServiceBusMessageContext(data, sbMessage, receiver)
+                new ServiceBusMessageContext(data, sbMessage, receiver, lockTTL)
               }
           }
       }

--- a/azure/service-bus/src/main/scala/com/commercetools/queue/azure/servicebus/ServiceBusQueueSubscriber.scala
+++ b/azure/service-bus/src/main/scala/com/commercetools/queue/azure/servicebus/ServiceBusQueueSubscriber.scala
@@ -21,9 +21,12 @@ import com.azure.messaging.servicebus.ServiceBusClientBuilder
 import com.azure.messaging.servicebus.models.ServiceBusReceiveMode
 import com.commercetools.queue.{Deserializer, QueuePuller, UnsealedQueueSubscriber}
 
+import scala.concurrent.duration.FiniteDuration
+
 private class ServiceBusQueueSubscriber[F[_], Data](
   val queueName: String,
-  builder: ServiceBusClientBuilder
+  builder: ServiceBusClientBuilder,
+  lockTTL: Option[FiniteDuration]
 )(implicit
   F: Async[F],
   deserializer: Deserializer[Data])
@@ -41,7 +44,7 @@ private class ServiceBusQueueSubscriber[F[_], Data](
       }
     }
     .map { receiver =>
-      new ServiceBusPuller(queueName, receiver)
+      new ServiceBusPuller(queueName, receiver, lockTTL)
     }
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import com.typesafe.tools.mima.core._
 import sbtcrossproject.CrossProject
 import laika.config.PrettyURLs
 import laika.config.LinkConfig
@@ -53,6 +54,10 @@ lazy val core: CrossProject = crossProject(JVMPlatform)
     name := "fs2-queues-core",
     libraryDependencies ++= List(
       "co.fs2" %%% "fs2-core" % Versions.fs2
+    ),
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.QueueClient.subscribe"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.commercetools.queue.QueueClient.subscribe")
     )
   )
 
@@ -111,6 +116,10 @@ lazy val otel4s = crossProject(JVMPlatform)
       "org.typelevel" %%% "otel4s-semconv" % Versions.otel4s,
       "org.typelevel" %%% "otel4s-semconv-experimental" % Versions.otel4s,
       "org.typelevel" %%% "otel4s-sdk-testkit" % Versions.otel4sSdk % Test
+    ),
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "com.commercetools.queue.otel4s.MeasuringQueueClient.subscribe")
     )
   )
   .dependsOn(core, testing % Test)
@@ -135,6 +144,16 @@ lazy val azureServiceBus = crossProject(JVMPlatform)
     name := "fs2-queues-azure-service-bus",
     libraryDependencies ++= List(
       "com.azure" % "azure-messaging-servicebus" % "7.17.17"
+    ),
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "com.commercetools.queue.azure.servicebus.ServiceBusClient.subscribe"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "com.commercetools.queue.azure.servicebus.ServiceBusMessageContext.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "com.commercetools.queue.azure.servicebus.ServiceBusPuller.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "com.commercetools.queue.azure.servicebus.ServiceBusQueueSubscriber.this")
     )
   )
   .dependsOn(core, testkit % Test)
@@ -158,6 +177,10 @@ lazy val awsSQS = crossProject(JVMPlatform)
     name := "fs2-queues-aws-sqs",
     libraryDependencies ++= List(
       "software.amazon.awssdk" % "sqs" % "2.42.41"
+    ),
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.aws.sqs.SQSClient.subscribe"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.aws.sqs.SQSSubscriber.this")
     )
   )
   .dependsOn(core)
@@ -177,6 +200,10 @@ lazy val gcpPubSub = crossProject(JVMPlatform)
     libraryDependencies ++= List(
       "com.google.cloud" % "google-cloud-pubsub" % "1.150.1",
       "com.google.cloud" % "google-cloud-monitoring" % "3.92.0"
+    ),
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.gcp.pubsub.PubSubClient.subscribe"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.commercetools.queue.gcp.pubsub.PubSubSubscriber.this")
     )
   )
   .dependsOn(core)

--- a/core/src/main/scala/com/commercetools/queue/QueueClient.scala
+++ b/core/src/main/scala/com/commercetools/queue/QueueClient.scala
@@ -15,6 +15,7 @@
  */
 
 package com.commercetools.queue
+import scala.concurrent.duration.FiniteDuration
 
 /**
  * The entry point to using queues.
@@ -45,8 +46,9 @@ sealed trait QueueClient[F[_]] {
 
   /**
    * Gives access to the subscription API.
+   * @param lockTTL allows to specify a custom lockTTL, that may differ from the one specified on the queue.
    */
-  def subscribe[T: Deserializer](name: String): QueueSubscriber[F, T]
+  def subscribe[T: Deserializer](name: String, lockTTL: Option[FiniteDuration] = None): QueueSubscriber[F, T]
 
 }
 

--- a/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubClient.scala
+++ b/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubClient.scala
@@ -25,6 +25,8 @@ import com.google.api.gax.rpc.{FixedTransportChannelProvider, TransportChannelPr
 import com.google.pubsub.v1.TopicName
 import io.grpc.netty.shaded.io.grpc.netty.{GrpcSslContexts, NettyChannelBuilder}
 
+import scala.concurrent.duration.FiniteDuration
+
 private class PubSubClient[F[_]: Async] private (
   project: String,
   channelProvider: TransportChannelProvider,
@@ -58,14 +60,15 @@ private class PubSubClient[F[_]: Async] private (
       executorProvider,
       endpoint)
 
-  override def subscribe[T: Deserializer](name: String): QueueSubscriber[F, T] =
+  override def subscribe[T: Deserializer](name: String, lockTTL: Option[FiniteDuration] = None): QueueSubscriber[F, T] =
     new PubSubSubscriber[F, T](
       name,
       configs.subscriptionName(project, name),
       channelProvider,
       credentials,
       executorProvider,
-      endpoint)
+      endpoint,
+      lockTTL)
 
 }
 

--- a/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubSubscriber.scala
+++ b/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubSubscriber.scala
@@ -16,6 +16,7 @@
 
 package com.commercetools.queue.gcp.pubsub
 
+import cats.data.OptionT
 import cats.effect.{Async, Resource}
 import cats.syntax.functor._
 import cats.syntax.monadError._
@@ -55,16 +56,17 @@ private class PubSubSubscriber[F[_], T](
         }
       }
       .evalMap { subscriber =>
-        lockTTL
-          .map(ttl => F.pure(ttl.toSeconds.toInt))
-          .getOrElse {
+        OptionT
+          .fromOption(lockTTL)
+          .map(_.toSeconds.toInt)
+          .getOrElseF(
             wrapFuture(
               F.delay(subscriber
                 .getSubscriptionCallable()
                 .futureCall(GetSubscriptionRequest.newBuilder().setSubscription(subscriptionName.toString()).build())))
               .map(_.getAckDeadlineSeconds)
               .adaptError(makePullQueueException(_, queueName))
-          }
+          )
           .map(new PubSubPuller[F, T](queueName, subscriptionName, subscriber, _))
       }
 

--- a/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubSubscriber.scala
+++ b/gcp/pubsub/src/main/scala/com/commercetools/queue/gcp/pubsub/PubSubSubscriber.scala
@@ -25,13 +25,16 @@ import com.google.api.gax.rpc.TransportChannelProvider
 import com.google.cloud.pubsub.v1.stub.{GrpcSubscriberStub, SubscriberStubSettings}
 import com.google.pubsub.v1.{GetSubscriptionRequest, SubscriptionName}
 
+import scala.concurrent.duration.FiniteDuration
+
 private class PubSubSubscriber[F[_], T](
   val queueName: String,
   subscriptionName: SubscriptionName,
   channelProvider: TransportChannelProvider,
   credentials: CredentialsProvider,
   executorProvider: Option[ExecutorProvider],
-  endpoint: Option[String]
+  endpoint: Option[String],
+  lockTTL: Option[FiniteDuration]
 )(implicit
   F: Async[F],
   deserializer: Deserializer[T])
@@ -52,15 +55,17 @@ private class PubSubSubscriber[F[_], T](
         }
       }
       .evalMap { subscriber =>
-        wrapFuture(
-          F.delay(subscriber
-            .getSubscriptionCallable()
-            .futureCall(GetSubscriptionRequest.newBuilder().setSubscription(subscriptionName.toString()).build())))
-          .map(sub => (subscriber, sub))
-          .adaptError(makePullQueueException(_, queueName))
-      }
-      .map { case (subscriber, subscription) =>
-        new PubSubPuller[F, T](queueName, subscriptionName, subscriber, subscription.getAckDeadlineSeconds())
+        lockTTL
+          .map(ttl => F.pure(ttl.toSeconds.toInt))
+          .getOrElse {
+            wrapFuture(
+              F.delay(subscriber
+                .getSubscriptionCallable()
+                .futureCall(GetSubscriptionRequest.newBuilder().setSubscription(subscriptionName.toString()).build())))
+              .map(_.getAckDeadlineSeconds)
+              .adaptError(makePullQueueException(_, queueName))
+          }
+          .map(new PubSubPuller[F, T](queueName, subscriptionName, subscriber, _))
       }
 
 }

--- a/otel4s/src/main/scala/com/commercetools/queue/otel4s/MeasuringQueueClient.scala
+++ b/otel4s/src/main/scala/com/commercetools/queue/otel4s/MeasuringQueueClient.scala
@@ -24,6 +24,8 @@ import org.typelevel.otel4s.metrics.Meter
 import org.typelevel.otel4s.semconv.experimental.attributes.MessagingExperimentalAttributes
 import org.typelevel.otel4s.trace.Tracer
 
+import scala.concurrent.duration.FiniteDuration
+
 private class MeasuringQueueClient[F[_]](
   private val underlying: QueueClient[F],
   commonAttributes: Attributes,
@@ -47,12 +49,13 @@ private class MeasuringQueueClient[F[_]](
       tracer,
       commonAttributes.added(MessagingExperimentalAttributes.MessagingDestinationName(name)))
 
-  override def subscribe[T: Deserializer](name: String): QueueSubscriber[F, T] =
+  override def subscribe[T: Deserializer](name: String, lockTTL: Option[FiniteDuration] = None): QueueSubscriber[F, T] =
     new MeasuringQueueSubscriber[F, T](
-      underlying.subscribe(name),
+      underlying.subscribe(name, lockTTL),
       metrics.forQueue(name),
       tracer,
-      commonAttributes.added(MessagingExperimentalAttributes.MessagingDestinationName(name)))
+      commonAttributes.added(MessagingExperimentalAttributes.MessagingDestinationName(name))
+    )
 
 }
 

--- a/testkit/src/main/scala/com/commercetools/queue/testkit/QueueClientSuite.scala
+++ b/testkit/src/main/scala/com/commercetools/queue/testkit/QueueClientSuite.scala
@@ -37,7 +37,7 @@ abstract class QueueClientSuite
   val waitingTime: FiniteDuration = 20.seconds
 
   final val originalMessageTTL: FiniteDuration = 10.minutes
-  final val originalLockTTL: FiniteDuration = 2.minutes
+  final val originalLockTTL: FiniteDuration = 1.minute
 
   /** Provide a way to acquire a queue client for the provider under test. */
   def client: Resource[IO, QueueClient[IO]]

--- a/testkit/src/main/scala/com/commercetools/queue/testkit/QueueSubscriberSuite.scala
+++ b/testkit/src/main/scala/com/commercetools/queue/testkit/QueueSubscriberSuite.scala
@@ -80,6 +80,43 @@ trait QueueSubscriberSuite extends CatsEffectSuite { self: QueueClientSuite =>
     }
   }
 
+  withQueue.test("subscriber uses the provided lockTTL when extending a message lock") { queueName =>
+    val client = clientFixture()
+    // The queue is created with `originalLockTTL` (1 minute). We subscribe with a longer, deliberately
+    // different lockTTL so that extending the lock keeps the message invisible *past* the entity's own lock
+    // duration. That extension is observable on every provider:
+    //  - SQS/PubSub: `extendLock` sets the visibility timeout / ack deadline to this exact value.
+    //  - Service Bus: `extendLock` auto-renews the lock for up to this duration (each renewal resets to the
+    //    entity lock duration), keeping the message locked beyond the 1 minute entity default.
+    val overriddenLockTTL = 90.seconds
+    client.publish(queueName).pusher.use { pusher =>
+      pusher.push("message", Map.empty, None)
+    } *> client.subscribe(queueName, lockTTL = Some(overriddenLockTTL)).puller.use { puller =>
+      for {
+        batch <- puller.pullBatch(1, waitingTime)
+        _ = assert(batch.nonEmpty, "expected a message to be pulled")
+        msg = batch.head.getOrElse(fail("expected a message to be pulled"))
+        _ <- msg.extendLock()
+        // Past the entity's 1 minute lock, but before the 90s override elapses: had the provided lockTTL not
+        // been applied, the message would already be back in the queue. It must still be locked here. A short
+        // poll wait is used so this check doesn't accidentally spill into the redelivery window.
+        _ <- IO.sleep(75.seconds)
+        _ <- assertIO(
+          puller.pullBatch(1, 1.second),
+          Chunk.empty,
+          "message should still be locked: the provided lockTTL must extend the lock past the entity default")
+        // And it must eventually reappear once the extended lock finally expires (generous upper bound to
+        // accommodate Service Bus, where the lock lingers up to one entity lock duration past the renewal window).
+        _ <- eventuallyBoolean(
+          puller.pullBatch(1, 2.seconds).map(_.nonEmpty),
+          "message should be redelivered after the extended lock expired",
+          retries = 30,
+          delay = 5.seconds
+        )
+      } yield ()
+    }
+  }
+
   withQueue.test("processWithAutoAck receives and acks all the messages") { queueName =>
     for {
       messages <- randomMessages(10)


### PR DESCRIPTION
This PR is adding the possibility of specifying an explicit `lockTTL` on `subscribe`. This will override the value that is set on the queue / subscription entity itself.

The main reason why we need this is that:
- the clients for both sqs and pubusb are fetching this value by calling the respective APIs on subscribe 
-  there are large-scale scenarios in which this may become a problem, and cause throttling from the cloud providers
- specifying this directly is avoiding those additional calls 